### PR TITLE
预览自适应窗口宽度

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "calamine",
  "chardetng",

--- a/app/src/components/Preview.vue
+++ b/app/src/components/Preview.vue
@@ -213,7 +213,7 @@ defineExpose({ scrollToLine });
 
 <template>
   <div class="preview-host">
-    <article ref="host" class="preview-content" v-html="html"></article>
+    <article ref="host" class="preview-content" :class="{ 'preview-content--fit': settings.previewFitWidth }" v-html="html"></article>
   </div>
 </template>
 
@@ -240,6 +240,10 @@ defineExpose({ scrollToLine });
   font-family: var(--font-ui);
   font-size: 15px;
   line-height: 1.7;
+}
+.preview-content--fit {
+  max-width: none;
+  padding: 28px 16px 64px;
 }
 :where(.preview-content) h1,
 :where(.preview-content) h2,
@@ -298,6 +302,9 @@ defineExpose({ scrollToLine });
 :where(.preview-content) table {
   border-collapse: collapse;
   margin: 1em 0;
+}
+:where(.preview-content--fit) table {
+  width: 100%;
 }
 :where(.preview-content) th,
 :where(.preview-content) td {

--- a/app/src/components/SettingsPanel.vue
+++ b/app/src/components/SettingsPanel.vue
@@ -160,6 +160,13 @@ const fontFamilies = [
 
         <section>
           <label>
+            <input type="checkbox" :checked="settings.previewFitWidth" @change="settings.togglePreviewFitWidth()" />
+            {{ t('settings.previewFitWidth') }}
+          </label>
+        </section>
+
+        <section>
+          <label>
             <input type="checkbox" :checked="settings.showFileTree" @change="settings.toggleFileTree()" />
             {{ t('settings.showFileTree') }}
           </label>

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -86,6 +86,7 @@ export const en = {
     lineNumbers: 'Line Numbers',
     livePreview: 'Live Preview (Markdown) — hide markers off-line, render headings, bold etc.',
     showOutline: 'Show Outline (Markdown)',
+    previewFitWidth: 'Preview Fit Width — stretch preview to fill window, no horizontal scrollbar',
     showFileTree: 'Show File Tree',
     spellCheck: 'Spell Check (browser)',
     focusMode: 'Focus Mode — dim non-active lines',

--- a/app/src/i18n/zh.ts
+++ b/app/src/i18n/zh.ts
@@ -88,6 +88,7 @@ export const zh: I18n = {
     lineNumbers: '显示行号',
     livePreview: '实时预览 (Markdown) — 离开行时隐藏标记符,渲染标题和粗体等',
     showOutline: '显示大纲 (Markdown)',
+    previewFitWidth: '预览自适应宽度 — 预览区铺满窗口,不出现横向滚动条',
     showFileTree: '显示文件树',
     spellCheck: '拼写检查 (浏览器)',
     focusMode: '专注模式 — 淡化非活动行',

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -21,6 +21,8 @@ interface Settings {
   uiFontSize: number;
   language: 'en' | 'zh';
   autoCheckUpdate: boolean;
+  // Preview layout
+  previewFitWidth: boolean;
   // Custom CSS theme override (path to a .css file on disk)
   customCssPath: string;
 }
@@ -53,6 +55,7 @@ function defaults(): Settings {
         return /^zh/i.test(nav) ? 'zh' : 'en';
       } catch { return 'en'; }
     })() as 'en' | 'zh',
+    previewFitWidth: false,
     customCssPath: '',
   };
 }
@@ -147,6 +150,10 @@ export const useSettingsStore = defineStore('settings', {
     },
     setCustomCssPath(p: string) {
       this.customCssPath = p;
+      this.persist();
+    },
+    togglePreviewFitWidth() {
+      this.previewFitWidth = !this.previewFitWidth;
       this.persist();
     },
   },


### PR DESCRIPTION
预览自适应窗口宽度 — Settings 面板中的一个新切换选项。
这对于内嵌了多列表格的文档来说非常重要

  启用时：
  - preview-content 上的 max-width: 760px 限制被移除 → 内容会拉伸以填充窗口
  - padding 从 36px 减少到 16px，以最大化可用宽度
  - 表格获得 width: 100%，因此多列表格会填满视口 — 无水平滚动条

  禁用时（默认）：行为与以前相同（居中，最大 760px）。