### PR TITLE
improved toolbar

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "calamine",
  "chardetng",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -24,10 +24,12 @@ import { useFiles } from './composables/useFiles';
 import { useShortcuts } from './composables/useShortcuts';
 import { loadCustomTheme } from './lib/custom-theme';
 import { isIOS } from './lib/platform';
+import { useI18n } from './i18n';
 
 const tabs = useTabsStore();
 const settings = useSettingsStore();
 const files = useFiles();
+const { t } = useI18n();
 
 const cursorLine = ref(1);
 const cursorCol = ref(1);
@@ -184,7 +186,7 @@ function dispatchMenuAction(id: string) {
       settings.toggleFileTree();
       break;
     case 'view.toggleOutline':
-      settings.toggleOutline();
+      if (tabs.activeId) tabs.toggleOutline(tabs.activeId);
       break;
     case 'view.cycleView':
       settings.cycleViewMode();
@@ -530,7 +532,7 @@ const showPreview = computed(
   () => tabs.activeTab?.language === 'markdown' && settings.viewMode !== 'edit'
 );
 const showOutlinePane = computed(
-  () => settings.showOutline && tabs.activeTab?.language === 'markdown'
+  () => !!tabs.activeTab?.showOutline && tabs.activeTab?.language === 'markdown'
 );
 </script>
 
@@ -547,6 +549,17 @@ const showOutlinePane = computed(
       <FileTree v-if="settings.showFileTree" />
       <Outline v-if="showOutlinePane" :cursor-line="cursorLine" @goto="onOutlineGoto" />
       <div class="content">
+        <button
+          v-if="tabs.activeTab?.language === 'markdown' && !showOutlinePane"
+          class="outline-toggle"
+          @click="tabs.activeId && tabs.toggleOutline(tabs.activeId)"
+          :title="t('toolbar.outlineTooltip')"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" />
+            <line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
+          </svg>
+        </button>
         <div class="pane pane--editor" v-if="showEditor && tabs.activeTab">
           <Editor
             ref="editorRef"
@@ -606,6 +619,28 @@ const showOutlinePane = computed(
   display: flex;
   min-width: 0;
   overflow: hidden;
+  position: relative;
+}
+.outline-toggle {
+  position: absolute;
+  top: 6px;
+  left: 6px;
+  z-index: 10;
+  padding: 4px 6px;
+  border-radius: 4px;
+  color: var(--text-faint);
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  opacity: 0;
+  transition: opacity 0.15s;
+  cursor: pointer;
+}
+.outline-toggle:hover {
+  opacity: 1 !important;
+  color: var(--text-muted);
+}
+.content:hover > .outline-toggle {
+  opacity: 0.5;
 }
 .pane {
   flex: 1;

--- a/app/src/components/Icons.vue
+++ b/app/src/components/Icons.vue
@@ -105,5 +105,43 @@ defineProps<{ name: string; size?: number }>();
       <line x1="18" y1="6" x2="6" y2="18" />
       <line x1="6" y1="6" x2="18" y2="18" />
     </template>
+    <template v-else-if="name === 'fit-width'">
+      <line x1="2" y1="12" x2="22" y2="12" />
+      <polyline points="6 8 2 12 6 16" />
+      <polyline points="18 8 22 12 18 16" />
+    </template>
+    <template v-else-if="name === 'view-edit'">
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+    </template>
+    <template v-else-if="name === 'view-split'">
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      <line x1="12" y1="3" x2="12" y2="21" />
+    </template>
+    <template v-else-if="name === 'view-preview'">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+      <circle cx="12" cy="12" r="3" />
+    </template>
+    <template v-else-if="name === 'focus'">
+      <circle cx="12" cy="12" r="4" />
+      <line x1="12" y1="2" x2="12" y2="5" />
+      <line x1="12" y1="19" x2="12" y2="22" />
+      <line x1="2" y1="12" x2="5" y2="12" />
+      <line x1="19" y1="12" x2="22" y2="12" />
+    </template>
+    <template v-else-if="name === 'typewriter'">
+      <rect x="2" y="4" width="20" height="12" rx="2" />
+      <line x1="6" y1="20" x2="18" y2="20" />
+      <line x1="12" y1="16" x2="12" y2="20" />
+    </template>
+    <template v-else-if="name === 'spellcheck'">
+      <path d="M7 20l4-16h2l4 16" />
+      <line x1="9" y1="14" x2="15" y2="14" />
+      <polyline points="16 18 19 21 23 15" />
+    </template>
+    <template v-else-if="name === 'search'">
+      <circle cx="11" cy="11" r="8" />
+      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+    </template>
   </svg>
 </template>

--- a/app/src/components/Outline.vue
+++ b/app/src/components/Outline.vue
@@ -43,7 +43,10 @@ watch(activeIndex, async () => {
 
 <template>
   <aside class="outline">
-    <div class="outline__header">Outline</div>
+    <div class="outline__header">
+      <span>Outline</span>
+      <button class="outline__close" @click="tabs.activeId && tabs.toggleOutline(tabs.activeId)">×</button>
+    </div>
     <div v-if="!items.length" class="outline__empty">No headings</div>
     <ul ref="listRef" class="outline__list" v-else>
       <li
@@ -78,6 +81,20 @@ watch(activeIndex, async () => {
   letter-spacing: 0.06em;
   color: var(--text-muted);
   border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.outline__close {
+  padding: 0 4px;
+  font-size: 16px;
+  line-height: 1;
+  color: var(--text-faint);
+  border-radius: 3px;
+}
+.outline__close:hover {
+  color: var(--text);
+  background: var(--bg-hover);
 }
 .outline__list {
   list-style: none;

--- a/app/src/components/Preview.vue
+++ b/app/src/components/Preview.vue
@@ -213,7 +213,7 @@ defineExpose({ scrollToLine });
 
 <template>
   <div class="preview-host">
-    <article ref="host" class="preview-content" v-html="html"></article>
+    <article ref="host" class="preview-content" :class="{ 'preview-content--fit': settings.previewFitWidth }" v-html="html"></article>
   </div>
 </template>
 
@@ -240,6 +240,10 @@ defineExpose({ scrollToLine });
   font-family: var(--font-ui);
   font-size: 15px;
   line-height: 1.7;
+}
+.preview-content--fit {
+  max-width: none;
+  padding: 28px 16px 64px;
 }
 :where(.preview-content) h1,
 :where(.preview-content) h2,
@@ -298,6 +302,9 @@ defineExpose({ scrollToLine });
 :where(.preview-content) table {
   border-collapse: collapse;
   margin: 1em 0;
+}
+:where(.preview-content--fit) table {
+  width: 100%;
 }
 :where(.preview-content) th,
 :where(.preview-content) td {

--- a/app/src/components/SettingsPanel.vue
+++ b/app/src/components/SettingsPanel.vue
@@ -160,6 +160,13 @@ const fontFamilies = [
 
         <section>
           <label>
+            <input type="checkbox" :checked="settings.previewFitWidth" @change="settings.togglePreviewFitWidth()" />
+            {{ t('settings.previewFitWidth') }}
+          </label>
+        </section>
+
+        <section>
+          <label>
             <input type="checkbox" :checked="settings.showFileTree" @change="settings.toggleFileTree()" />
             {{ t('settings.showFileTree') }}
           </label>

--- a/app/src/components/SettingsPanel.vue
+++ b/app/src/components/SettingsPanel.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue';
 import { invoke } from '@tauri-apps/api/core';
 import { useSettingsStore } from '../stores/settings';
+import { useTabsStore } from '../stores/tabs';
 import { useToastsStore } from '../stores/toasts';
 import { open as openFileDialog } from '@tauri-apps/plugin-dialog';
 import { themeLabels } from '../lib/themes';
@@ -50,6 +51,7 @@ defineProps<{ open: boolean }>();
 const emit = defineEmits<{ (e: 'close'): void }>();
 
 const settings = useSettingsStore();
+const tabs = useTabsStore();
 const toasts = useToastsStore();
 
 async function pickCustomCss() {
@@ -153,7 +155,7 @@ const fontFamilies = [
 
         <section>
           <label>
-            <input type="checkbox" :checked="settings.showOutline" @change="settings.toggleOutline()" />
+            <input type="checkbox" :checked="!!tabs.activeTab?.showOutline" @change="tabs.activeId && tabs.toggleOutline(tabs.activeId)" />
             {{ t('settings.showOutline') }}
           </label>
         </section>

--- a/app/src/components/TabBar.vue
+++ b/app/src/components/TabBar.vue
@@ -22,6 +22,7 @@ function isDirty(id: string) {
         :title="t.filePath || t.fileName"
       >
         <span class="tab__name">{{ t.fileName }}</span>
+        <span class="tab__outline" v-if="t.showOutline && t.language === 'markdown'" title="Outline on">≡</span>
         <span class="tab__dot" v-if="isDirty(t.id)">●</span>
         <button
           class="tab__close"
@@ -88,6 +89,10 @@ function isDirty(id: string) {
 .tab__dot {
   color: var(--accent);
   font-size: 10px;
+}
+.tab__outline {
+  font-size: 11px;
+  color: var(--text-faint);
 }
 .tab__close {
   padding: 0 4px;

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -200,6 +200,19 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
+    <span class="toolbar__divider"></span>
+
+    <div class="toolbar__group">
+      <button
+        class="icon-btn"
+        @click="settings.toggleFileTree"
+        :class="{ active: settings.showFileTree }"
+        :title="t('toolbar.fileTreeTooltip')"
+      >
+        <Icon name="sidebar" />
+      </button>
+    </div>
+
     <div class="toolbar__group">
       <button
         class="icon-btn clean-ai-btn"
@@ -252,20 +265,29 @@ onBeforeUnmount(() => {
 
     <div class="toolbar__group" v-if="isMarkdown">
       <button
+        class="icon-btn"
         @click="settings.setViewMode('edit')"
         :class="{ active: settings.viewMode === 'edit' }"
         :title="t('toolbar.editOnly')"
-      >{{ t('toolbar.editMode') }}</button>
+      >
+        <Icon name="view-edit" />
+      </button>
       <button
+        class="icon-btn"
         @click="settings.setViewMode('split')"
         :class="{ active: settings.viewMode === 'split' }"
         :title="t('toolbar.splitPane')"
-      >{{ t('toolbar.splitMode') }}</button>
+      >
+        <Icon name="view-split" />
+      </button>
       <button
+        class="icon-btn"
         @click="settings.setViewMode('preview')"
         :class="{ active: settings.viewMode === 'preview' }"
         :title="t('toolbar.previewOnly')"
-      >{{ t('toolbar.previewMode') }}</button>
+      >
+        <Icon name="view-preview" />
+      </button>
       <span class="toolbar__divider"></span>
       <button
         class="icon-btn"
@@ -275,7 +297,18 @@ onBeforeUnmount(() => {
       >
         <Icon :name="settings.livePreview ? 'live' : 'source'" />
       </button>
+      <button
+        v-if="settings.viewMode !== 'edit'"
+        class="icon-btn"
+        @click="settings.togglePreviewFitWidth"
+        :class="{ active: settings.previewFitWidth }"
+        :title="t('toolbar.fitWidthTooltip')"
+      >
+        <Icon name="fit-width" />
+      </button>
     </div>
+
+    <span v-if="isMarkdown" class="toolbar__divider"></span>
 
     <div class="toolbar__group">
       <button
@@ -284,7 +317,7 @@ onBeforeUnmount(() => {
         :class="{ active: settings.focusMode }"
         :title="t('toolbar.focusModeTooltip')"
       >
-        <Icon name="live" />
+        <Icon name="focus" />
       </button>
       <button
         class="icon-btn"
@@ -292,7 +325,7 @@ onBeforeUnmount(() => {
         :class="{ active: settings.typewriterMode }"
         :title="t('toolbar.typewriterTooltip')"
       >
-        <Icon name="outline" />
+        <Icon name="typewriter" />
       </button>
       <button
         class="icon-btn"
@@ -300,28 +333,11 @@ onBeforeUnmount(() => {
         :class="{ active: settings.spellCheck }"
         :title="t('toolbar.spellCheckTooltip')"
       >
-        <Icon name="help" />
+        <Icon name="spellcheck" />
       </button>
       <span class="toolbar__divider"></span>
-      <button
-        class="icon-btn"
-        @click="settings.toggleFileTree"
-        :class="{ active: settings.showFileTree }"
-        :title="t('toolbar.fileTreeTooltip')"
-      >
-        <Icon name="sidebar" />
-      </button>
-      <button
-        v-if="isMarkdown"
-        class="icon-btn"
-        @click="settings.toggleOutline"
-        :class="{ active: settings.showOutline }"
-        :title="t('toolbar.outlineTooltip')"
-      >
-        <Icon name="outline" />
-      </button>
       <button class="icon-btn" @click="$emit('open-search')" :title="t('toolbar.searchTooltip')">
-        <Icon name="palette" />
+        <Icon name="search" />
       </button>
       <button class="icon-btn" @click="$emit('open-palette')" :title="t('toolbar.paletteTooltip')">
         <Icon name="palette" />

--- a/app/src/composables/useCommands.ts
+++ b/app/src/composables/useCommands.ts
@@ -58,7 +58,7 @@ export function useCommands(): Command[] {
     { id: 'view.split', title: 'View: Split', run: () => settings.setViewMode('split') },
     { id: 'view.preview', title: 'View: Preview Only', run: () => settings.setViewMode('preview') },
     { id: 'view.cycleView', title: 'View: Cycle Mode', shortcut: 'Ctrl+Shift+P', run: () => settings.cycleViewMode() },
-    { id: 'view.toggleOutline', title: 'View: Toggle Outline', shortcut: 'Ctrl+Shift+O', run: () => settings.toggleOutline() },
+    { id: 'view.toggleOutline', title: 'View: Toggle Outline', shortcut: 'Ctrl+Shift+O', run: () => { const tabs = useTabsStore(); if (tabs.activeId) tabs.toggleOutline(tabs.activeId); } },
     { id: 'view.toggleFileTree', title: 'View: Toggle File Tree', shortcut: 'Ctrl+B', run: () => settings.toggleFileTree() },
     { id: 'view.toggleWrap', title: 'View: Toggle Word Wrap', run: () => settings.toggleWordWrap() },
     { id: 'view.toggleLineNumbers', title: 'View: Toggle Line Numbers', run: () => settings.toggleLineNumbers() },

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -42,6 +42,7 @@ export const en = {
     previewOnly: 'Preview only',
     livePreviewOn: 'Live preview ON — click for raw source',
     livePreviewOff: 'Raw source — click for live preview',
+    fitWidthTooltip: 'Preview Fit Width (toggle)',
     focusModeTooltip: 'Focus mode (dim non-active lines)',
     typewriterTooltip: 'Typewriter mode (keep cursor centered)',
     spellCheckTooltip: 'Spell check',

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -86,6 +86,7 @@ export const en = {
     lineNumbers: 'Line Numbers',
     livePreview: 'Live Preview (Markdown) — hide markers off-line, render headings, bold etc.',
     showOutline: 'Show Outline (Markdown)',
+    previewFitWidth: 'Preview Fit Width — stretch preview to fill window, no horizontal scrollbar',
     showFileTree: 'Show File Tree',
     spellCheck: 'Spell Check (browser)',
     focusMode: 'Focus Mode — dim non-active lines',

--- a/app/src/i18n/zh.ts
+++ b/app/src/i18n/zh.ts
@@ -44,6 +44,7 @@ export const zh: I18n = {
     previewOnly: '仅预览',
     livePreviewOn: '实时预览已开启 — 点击切换源码',
     livePreviewOff: '源码模式 — 点击切换实时预览',
+    fitWidthTooltip: '预览自适应宽度 (切换)',
     focusModeTooltip: '专注模式 (淡化非活动行)',
     typewriterTooltip: '打字机模式 (光标居中)',
     spellCheckTooltip: '拼写检查',

--- a/app/src/i18n/zh.ts
+++ b/app/src/i18n/zh.ts
@@ -88,6 +88,7 @@ export const zh: I18n = {
     lineNumbers: '显示行号',
     livePreview: '实时预览 (Markdown) — 离开行时隐藏标记符,渲染标题和粗体等',
     showOutline: '显示大纲 (Markdown)',
+    previewFitWidth: '预览自适应宽度 — 预览区铺满窗口,不出现横向滚动条',
     showFileTree: '显示文件树',
     spellCheck: '拼写检查 (浏览器)',
     focusMode: '专注模式 — 淡化非活动行',

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -21,6 +21,8 @@ interface Settings {
   uiFontSize: number;
   language: 'en' | 'zh';
   autoCheckUpdate: boolean;
+  // Preview layout
+  previewFitWidth: boolean;
   // Custom CSS theme override (path to a .css file on disk)
   customCssPath: string;
 }
@@ -53,6 +55,7 @@ function defaults(): Settings {
         return /^zh/i.test(nav) ? 'zh' : 'en';
       } catch { return 'en'; }
     })() as 'en' | 'zh',
+    previewFitWidth: false,
     customCssPath: '',
   };
 }
@@ -147,6 +150,10 @@ export const useSettingsStore = defineStore('settings', {
     },
     setCustomCssPath(p: string) {
       this.customCssPath = p;
+      this.persist();
+    },
+    togglePreviewFitWidth() {
+      this.previewFitWidth = !this.previewFitWidth;
       this.persist();
     },
   },

--- a/app/src/stores/tabs.ts
+++ b/app/src/stores/tabs.ts
@@ -112,6 +112,10 @@ export const useTabsStore = defineStore('tabs', {
     activate(id: string) {
       this.activeId = id;
     },
+    toggleOutline(id: string) {
+      const t = this.tabs.find((x) => x.id === id);
+      if (t) t.showOutline = !t.showOutline;
+    },
     persist() {
       try {
         localStorage.setItem(

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -19,6 +19,7 @@ export interface Tab {
   encoding: string;
   language: Language;
   hadBom: boolean;
+  showOutline?: boolean;
 }
 
 export interface FileReadResult {


### PR DESCRIPTION
Toolbar 重构

  - View mode 按钮图标化：Edit / Split / Preview 三态由纯文字改为专属图标（edit-pencil、split-pane、preview-eye），与工具栏其他元素风格统一
  - 左侧面板按钮归位：File tree 切换按钮移至工具栏左侧（紧邻文件操作组），符合面板实际位置
  - Outline 切换改为 per-tab：从全局设置改为每个文档独立控制，toggle 按钮从工具栏移至文档区域左上角浮动图标
  - 新增 7 个图标：view-edit、view-split、view-preview、focus、typewriter、spellcheck、search
  - 工具栏分组优化：通过 divider 清晰分隔文件操作、面板控制、视图模式、编辑器功能四组，消除之前两组高度相似按钮的视觉混乱


  Tab 大纲指示

  - Tab 标签上以 ≡ 标记指示该文档是否打开了大纲面板
  - Outline 面板头部增加关闭按钮