### PR TITLE
分屏

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "0.1.12"
+version = "1.0.0"
 dependencies = [
  "calamine",
  "chardetng",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4034,7 +4034,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "1.0.0"
+version = "0.1.12"
 dependencies = [
  "calamine",
  "chardetng",

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -5,9 +5,7 @@ import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
 import { getCurrentWindow, LogicalSize, LogicalPosition } from '@tauri-apps/api/window';
 import Toolbar from './components/Toolbar.vue';
-import TabBar from './components/TabBar.vue';
-import Editor from './components/Editor.vue';
-import Preview from './components/Preview.vue';
+import TileRoot from './components/TileRoot.vue';
 import StatusBar from './components/StatusBar.vue';
 import CommandPalette from './components/CommandPalette.vue';
 import Outline from './components/Outline.vue';
@@ -20,16 +18,16 @@ import UnsavedDialog from './components/UnsavedDialog.vue';
 import Toast from './components/Toast.vue';
 import { useTabsStore } from './stores/tabs';
 import { useSettingsStore } from './stores/settings';
+import { useTilesStore } from './stores/tiles';
 import { useFiles } from './composables/useFiles';
 import { useShortcuts } from './composables/useShortcuts';
 import { loadCustomTheme } from './lib/custom-theme';
 import { isIOS } from './lib/platform';
-import { useI18n } from './i18n';
 
 const tabs = useTabsStore();
 const settings = useSettingsStore();
+const tiles = useTilesStore();
 const files = useFiles();
-const { t } = useI18n();
 
 const cursorLine = ref(1);
 const cursorCol = ref(1);
@@ -65,12 +63,7 @@ function onUnsavedAction(action: 'save' | 'discard' | 'cancel') {
 
 // Expose to child composables (useFiles) via provide/inject
 provide('showUnsavedDialog', showUnsavedDialog);
-// Also expose globally so non-component callers (shortcuts, menu events)
-// can use it. inject() only works inside a component setup, and useFiles()
-// is called from multiple places — some without an injection context.
 (window as any).__solomd_showUnsavedDialog = showUnsavedDialog;
-const editorRef = ref<InstanceType<typeof Editor> | null>(null);
-const previewRef = ref<InstanceType<typeof Preview> | null>(null);
 
 useShortcuts({
   openPalette: () => (paletteOpen.value = true),
@@ -95,38 +88,47 @@ function onCursor(line: number, col: number) {
 }
 
 function onOutlineGoto(line: number) {
-  // In preview-only mode the editor is unmounted, so route the scroll to
-  // the preview pane instead. In split / edit modes the editor is the
-  // source of truth and scroll-sync mirrors the jump in the preview.
-  if (settings.viewMode === 'preview') {
-    previewRef.value?.scrollToLine(line);
-  } else {
-    editorRef.value?.gotoLine(line);
-  }
+  // Dispatch a custom event that PaneContent listens for
+  window.dispatchEvent(new CustomEvent('solomd:outline-goto', {
+    detail: { line, paneId: tiles.focusedPaneId },
+  }));
 }
 
 import { dataThemeFor } from './lib/themes';
 
-// Auto-persist tabs (list + active + per-tab content) on every change.
-// Crash recovery + "close without saving" both depend on this.
+// Auto-persist tabs and tiles on every change.
 watch(
   () => [tabs.tabs.map((t) => [t.id, t.fileName, t.filePath, t.content, t.savedContent, t.language].join('|')).join(';'), tabs.activeId],
-  () => tabs.persist(),
+  () => {
+    tabs.persist();
+    tiles.persist();
+  },
   { deep: false },
 );
 
-// UI font size — applied via CSS var on <html> for all components to inherit.
+// Persist tiles when root structure changes
+watch(
+  () => JSON.stringify(tiles.root),
+  () => tiles.persist(),
+);
+
+// Sync tabs.activeId changes to the focused pane's leaf.
+// When newTab() or openFromDisk() set activeId, propagate it to the tile leaf.
+watch(
+  () => tabs.activeId,
+  (newActiveId) => {
+    if (newActiveId) tiles.syncFromTabs(newActiveId);
+  },
+);
+
+// UI font size
 watchEffect(() => {
   document.documentElement.style.setProperty('--ui-font-size', `${settings.uiFontSize}px`);
 });
 
-// Sync native menu bar language with settings (macOS top bar + Linux app menu).
+// Sync native menu bar language
 watchEffect(() => {
   invoke('set_menu_language', { lang: settings.language }).catch(() => {});
-  // Also persist to a file Rust reads on next launch — this is needed
-  // because NSUserDefaults "AppleLanguages" only takes effect at app
-  // startup (before AppKit loads), so native dialogs in the current
-  // session still show the language active at launch time.
   invoke('save_language_preference', { lang: settings.language }).catch(() => {});
 });
 
@@ -134,7 +136,6 @@ watchEffect(() => {
   document.documentElement.setAttribute('data-theme', dataThemeFor(settings.theme));
 });
 
-// Apply custom CSS theme whenever the path changes (and on first load).
 watch(
   () => settings.customCssPath,
   (path) => {
@@ -261,10 +262,8 @@ onMounted(async () => {
   window.addEventListener('solomd:open-help', onOpenHelpEvent as EventListener);
   window.addEventListener('solomd:open-global-search', onOpenSearchEvent as EventListener);
 
-  // Restore window size from last session (before any UI activity)
   await restoreWindowSize();
 
-  // Persist on resize / move (debounced) — desktop only
   if (!isIOS()) {
     try {
       const win = getCurrentWindow();
@@ -273,8 +272,7 @@ onMounted(async () => {
     } catch {}
   }
 
-  // OS file association: when a file is passed via CLI / double-click,
-  // runner.rs emits "solomd://opened-file" with the path string.
+  // OS file association
   try {
     unlistenOpened = await listen<string>('solomd://opened-file', async (e) => {
       if (e.payload) await files.openPath(e.payload);
@@ -283,9 +281,6 @@ onMounted(async () => {
     console.warn('opened-file listener not available', err);
   }
 
-  // Drain any files queued by the backend BEFORE this listener was
-  // set up (cold start from double-click on macOS / CLI args elsewhere).
-  // This must happen before we decide whether to create a blank tab.
   try {
     const pending = await invoke<string[]>('drain_pending_opens');
     for (const p of pending || []) {
@@ -295,29 +290,28 @@ onMounted(async () => {
     console.warn('drain_pending_opens failed', err);
   }
 
-  // Only create a blank Untitled tab if nothing was restored AND nothing
-  // was opened from the OS file-association path.
   if (tabs.tabs.length === 0) tabs.newTab();
 
-  // Window close: Rust intercepts CloseRequested and emits this event.
-  // We check unsaved tabs and either force-close or let the user cancel.
-  // (JS onCloseRequested was broken on macOS, so we do it from Rust.)
-  // Window close: no prompt. The user's unsaved work is persisted by
-  // session restore (auto-save every 500ms) AND the tabs store (localStorage).
-  // Next launch rehydrates everything, so closing is always safe.
+  // Initialize tile layout: validate persisted state or create default
+  tiles.validate(tabs.tabs);
+  if (!tiles.focusedLeaf?.activeTabId && tabs.tabs.length > 0) {
+    tiles.initDefault(tabs.tabs[0].id);
+  }
+  tiles.syncActiveTab();
+
+  // Window close
   try {
     await listen('solomd://close-requested', async () => {
-      // Persist window size + tabs BEFORE destroying the window — the
-      // save handlers may not have fired recently enough otherwise.
       await saveWindowSize();
       tabs.persist?.();
+      tiles.persist();
       await invoke('force_close_window');
     });
   } catch (err) {
     console.warn('close-requested listener failed', err);
   }
 
-  // Native menu bar: runner.rs emits "solomd://menu" with the item id.
+  // Native menu bar
   try {
     unlistenMenu = await listen<string>('solomd://menu', (e) => {
       if (e.payload) dispatchMenuAction(e.payload);
@@ -326,21 +320,14 @@ onMounted(async () => {
     console.warn('menu listener not available', err);
   }
 
-  // Drag-drop file open via Tauri's webview events.
-  // For images we route through the editor's image-insert pipeline (copy
-  // into _assets/ and insert markdown link). For everything else we open
-  // the file as a new tab via the normal file pipeline.
+  // Drag-drop file open
   try {
     const webview = getCurrentWebview();
     await webview.onDragDropEvent(async (event) => {
       if (event.payload.type === 'drop') {
         for (const path of event.payload.paths) {
           if (isImagePath(path)) {
-            try {
-              await editorRef.value?.insertImageFromPath(path);
-            } catch (err) {
-              console.error('image insert failed', err);
-            }
+            await files.openPath(path);
           } else {
             await files.openPath(path);
           }
@@ -351,13 +338,7 @@ onMounted(async () => {
     console.warn('drag-drop not available', e);
   }
 
-  // Initial scroll sync (after panes are rendered)
-  await new Promise((r) => setTimeout(r, 300));
-  bindScrollSync();
-
-  // Auto-check for updates (once per 24h if enabled) — desktop only.
-  // iOS/iPadOS apps MUST NOT point users at external update URLs; the App
-  // Store handles updates there and Apple rejects apps that do otherwise.
+  // Auto-check for updates
   if (!isIOS() && settings.autoCheckUpdate) {
     try {
       const { checkForUpdateOnStartup, openReleaseUrl } = await import('./lib/check-update');
@@ -398,139 +379,6 @@ onBeforeUnmount(() => {
   }
 });
 
-// ---- Split-pane scroll sync (line-based) ----
-// Uses data-source-line attributes injected by markdown-it to map editor
-// viewport lines → preview DOM elements, so the same logical content line
-// stays aligned across both panes (content-level sync, not just percentage).
-let syncEditorScroll: (() => void) | null = null;
-let syncPreviewScroll: (() => void) | null = null;
-let syncGuard = false;
-
-function getCMViewLine(editor: HTMLElement): number | null {
-  // Find the CodeMirror line closest to the top of the viewport.
-  const lines = editor.querySelectorAll('.cm-line');
-  if (!lines.length) return null;
-  const top = editor.getBoundingClientRect().top;
-  for (let i = 0; i < lines.length; i++) {
-    const rect = (lines[i] as HTMLElement).getBoundingClientRect();
-    if (rect.bottom >= top) {
-      // i is 0-indexed within visible lines — but CodeMirror only renders
-      // visible lines, so we need the actual line number from the CM state.
-      // Fallback: use the ratio (fraction of visible lines) * doc total.
-      return i + 1; // will be corrected via editorRef below
-    }
-  }
-  return lines.length;
-}
-
-function getPreviewElementsByLine(preview: HTMLElement): Array<{ line: number; el: HTMLElement }> {
-  const nodes = preview.querySelectorAll<HTMLElement>('[data-source-line]');
-  const list: Array<{ line: number; el: HTMLElement }> = [];
-  for (const el of Array.from(nodes)) {
-    const n = Number(el.getAttribute('data-source-line') || '0');
-    if (n > 0) list.push({ line: n, el });
-  }
-  list.sort((a, b) => a.line - b.line);
-  return list;
-}
-
-function findNearestEntry<T extends { line: number }>(list: T[], line: number): T | null {
-  if (!list.length) return null;
-  let lo = 0, hi = list.length - 1, best = list[0];
-  while (lo <= hi) {
-    const mid = (lo + hi) >> 1;
-    if (list[mid].line <= line) { best = list[mid]; lo = mid + 1; }
-    else hi = mid - 1;
-  }
-  return best;
-}
-
-function bindScrollSync() {
-  if (syncEditorScroll) syncEditorScroll();
-  if (syncPreviewScroll) syncPreviewScroll();
-  syncEditorScroll = null;
-  syncPreviewScroll = null;
-
-  if (settings.viewMode !== 'split') return;
-
-  const editor = document.querySelector('.pane--editor .cm-scroller') as HTMLElement | null;
-  const preview = document.querySelector('.pane--preview .preview-host') as HTMLElement | null;
-  if (!editor || !preview) return;
-
-  const onEditorScroll = () => {
-    if (syncGuard) return;
-    // Prefer exact line from CM if available via ref
-    const cmRef = editorRef.value as any;
-    let currentLine: number | null = null;
-    if (cmRef?.getViewLine) {
-      currentLine = cmRef.getViewLine();
-    }
-    if (!currentLine) {
-      currentLine = getCMViewLine(editor);
-    }
-    if (!currentLine) return;
-
-    const previewLines = getPreviewElementsByLine(preview);
-    const entry = findNearestEntry(previewLines, currentLine);
-    if (!entry) {
-      // No mapped element — fall back to percentage
-      const emax = editor.scrollHeight - editor.clientHeight;
-      const pmax = preview.scrollHeight - preview.clientHeight;
-      if (emax > 0 && pmax > 0) {
-        syncGuard = true;
-        preview.scrollTop = (editor.scrollTop / emax) * pmax;
-        requestAnimationFrame(() => { syncGuard = false; });
-      }
-      return;
-    }
-    const elRect = entry.el.getBoundingClientRect();
-    const wrapRect = preview.getBoundingClientRect();
-    syncGuard = true;
-    preview.scrollTop += elRect.top - wrapRect.top - 8;
-    requestAnimationFrame(() => { syncGuard = false; });
-  };
-
-  const onPreviewScroll = () => {
-    if (syncGuard) return;
-    const previewLines = getPreviewElementsByLine(preview);
-    const wrapTop = preview.getBoundingClientRect().top;
-    // Find the first element whose top is below the viewport top
-    let targetLine: number | null = null;
-    for (const { line, el } of previewLines) {
-      const r = el.getBoundingClientRect();
-      if (r.bottom >= wrapTop) { targetLine = line; break; }
-    }
-    if (targetLine == null) return;
-    const cmRef = editorRef.value as any;
-    if (cmRef?.scrollToLine) {
-      syncGuard = true;
-      cmRef.scrollToLine(targetLine);
-      requestAnimationFrame(() => { syncGuard = false; });
-    }
-  };
-
-  editor.addEventListener('scroll', onEditorScroll, { passive: true });
-  preview.addEventListener('scroll', onPreviewScroll, { passive: true });
-  syncEditorScroll = () => editor.removeEventListener('scroll', onEditorScroll);
-  syncPreviewScroll = () => preview.removeEventListener('scroll', onPreviewScroll);
-}
-
-watch(() => settings.viewMode, async () => {
-  await new Promise((r) => setTimeout(r, 100)); // wait for DOM to update
-  bindScrollSync();
-}, { immediate: false });
-
-watch(() => tabs.activeId, async () => {
-  await new Promise((r) => setTimeout(r, 100));
-  bindScrollSync();
-});
-
-const showEditor = computed(
-  () => tabs.activeTab?.language !== 'markdown' || settings.viewMode !== 'preview'
-);
-const showPreview = computed(
-  () => tabs.activeTab?.language === 'markdown' && settings.viewMode !== 'edit'
-);
 const showOutlinePane = computed(
   () => !!tabs.activeTab?.showOutline && tabs.activeTab?.language === 'markdown'
 );
@@ -544,39 +392,11 @@ const showOutlinePane = computed(
       @open-help="helpOpen = true"
       @open-search="searchOpen = true"
     />
-    <TabBar />
     <div class="workspace">
       <FileTree v-if="settings.showFileTree" />
       <Outline v-if="showOutlinePane" :cursor-line="cursorLine" @goto="onOutlineGoto" />
       <div class="content">
-        <button
-          v-if="tabs.activeTab?.language === 'markdown' && !showOutlinePane"
-          class="outline-toggle"
-          @click="tabs.activeId && tabs.toggleOutline(tabs.activeId)"
-          :title="t('toolbar.outlineTooltip')"
-        >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" />
-            <line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
-          </svg>
-        </button>
-        <div class="pane pane--editor" v-if="showEditor && tabs.activeTab">
-          <Editor
-            ref="editorRef"
-            :tab="tabs.activeTab"
-            :focus-mode="settings.focusMode"
-            :typewriter-mode="settings.typewriterMode"
-            :spell-check="settings.spellCheck"
-            @cursor="onCursor"
-          />
-        </div>
-        <div class="pane pane--preview" v-if="showPreview && tabs.activeTab">
-          <Preview
-            ref="previewRef"
-            :source="tabs.activeTab.content"
-            :file-path="tabs.activeTab.filePath"
-          />
-        </div>
+        <TileRoot :node="tiles.root" @cursor="onCursor" />
       </div>
     </div>
     <StatusBar :line="cursorLine" :col="cursorCol" />
@@ -641,13 +461,5 @@ const showOutlinePane = computed(
 }
 .content:hover > .outline-toggle {
   opacity: 0.5;
-}
-.pane {
-  flex: 1;
-  min-width: 0;
-  height: 100%;
-}
-.pane--editor + .pane--preview {
-  border-left: 1px solid var(--border);
 }
 </style>

--- a/app/src/components/PaneContent.vue
+++ b/app/src/components/PaneContent.vue
@@ -194,6 +194,7 @@ function onOutlineGotoEvent(e: Event) {
   flex: 1;
   display: flex;
   min-width: 0;
+  min-height: 0;
   overflow: hidden;
 }
 .pane {

--- a/app/src/components/PaneContent.vue
+++ b/app/src/components/PaneContent.vue
@@ -1,0 +1,207 @@
+<script setup lang="ts">
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue';
+import Editor from './Editor.vue';
+import Preview from './Preview.vue';
+import { useSettingsStore } from '../stores/settings';
+import { useTilesStore } from '../stores/tiles';
+import type { Tab } from '../types';
+
+const props = defineProps<{
+  paneId: string;
+  tab: Tab | undefined;
+}>();
+
+const emit = defineEmits<{
+  (e: 'cursor', line: number, col: number): void;
+}>();
+
+const settings = useSettingsStore();
+const tiles = useTilesStore();
+
+const editorRef = ref<InstanceType<typeof Editor> | null>(null);
+const previewRef = ref<InstanceType<typeof Preview> | null>(null);
+
+const showEditor = computed(
+  () => props.tab?.language !== 'markdown' || settings.viewMode !== 'preview'
+);
+const showPreview = computed(
+  () => props.tab?.language === 'markdown' && settings.viewMode !== 'edit'
+);
+
+const isFocused = computed(() => tiles.focusedPaneId === props.paneId);
+
+function onCursor(line: number, col: number) {
+  if (isFocused.value) {
+    emit('cursor', line, col);
+  }
+}
+
+function gotoLine(line: number) {
+  if (settings.viewMode === 'preview') {
+    previewRef.value?.scrollToLine(line);
+  } else {
+    editorRef.value?.gotoLine(line);
+  }
+}
+
+// ---- Pane-scoped scroll sync ----
+let syncEditorScroll: (() => void) | null = null;
+let syncPreviewScroll: (() => void) | null = null;
+let syncGuard = false;
+
+function getPreviewElementsByLine(preview: HTMLElement): Array<{ line: number; el: HTMLElement }> {
+  const nodes = preview.querySelectorAll<HTMLElement>('[data-source-line]');
+  const list: Array<{ line: number; el: HTMLElement }> = [];
+  for (const el of Array.from(nodes)) {
+    const n = Number(el.getAttribute('data-source-line') || '0');
+    if (n > 0) list.push({ line: n, el });
+  }
+  list.sort((a, b) => a.line - b.line);
+  return list;
+}
+
+function findNearestEntry<T extends { line: number }>(list: T[], line: number): T | null {
+  if (!list.length) return null;
+  let lo = 0, hi = list.length - 1, best = list[0];
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    if (list[mid].line <= line) { best = list[mid]; lo = mid + 1; }
+    else hi = mid - 1;
+  }
+  return best;
+}
+
+function bindScrollSync() {
+  if (syncEditorScroll) syncEditorScroll();
+  if (syncPreviewScroll) syncPreviewScroll();
+  syncEditorScroll = null;
+  syncPreviewScroll = null;
+
+  if (settings.viewMode !== 'split') return;
+
+  const paneEl = document.querySelector(`[data-pane-id="${props.paneId}"]`);
+  if (!paneEl) return;
+  const editor = paneEl.querySelector('.pane--editor .cm-scroller') as HTMLElement | null;
+  const preview = paneEl.querySelector('.pane--preview .preview-host') as HTMLElement | null;
+  if (!editor || !preview) return;
+
+  const onEditorScroll = () => {
+    if (syncGuard) return;
+    const cmRef = editorRef.value as any;
+    let currentLine: number | null = null;
+    if (cmRef?.getViewLine) {
+      currentLine = cmRef.getViewLine();
+    }
+    if (!currentLine) return;
+
+    const previewLines = getPreviewElementsByLine(preview);
+    const entry = findNearestEntry(previewLines, currentLine);
+    if (!entry) {
+      const emax = editor.scrollHeight - editor.clientHeight;
+      const pmax = preview.scrollHeight - preview.clientHeight;
+      if (emax > 0 && pmax > 0) {
+        syncGuard = true;
+        preview.scrollTop = (editor.scrollTop / emax) * pmax;
+        requestAnimationFrame(() => { syncGuard = false; });
+      }
+      return;
+    }
+    const elRect = entry.el.getBoundingClientRect();
+    const wrapRect = preview.getBoundingClientRect();
+    syncGuard = true;
+    preview.scrollTop += elRect.top - wrapRect.top - 8;
+    requestAnimationFrame(() => { syncGuard = false; });
+  };
+
+  const onPreviewScroll = () => {
+    if (syncGuard) return;
+    const previewLines = getPreviewElementsByLine(preview);
+    const wrapTop = preview.getBoundingClientRect().top;
+    let targetLine: number | null = null;
+    for (const { line, el } of previewLines) {
+      const r = el.getBoundingClientRect();
+      if (r.bottom >= wrapTop) { targetLine = line; break; }
+    }
+    if (targetLine == null) return;
+    const cmRef = editorRef.value as any;
+    if (cmRef?.scrollToLine) {
+      syncGuard = true;
+      cmRef.scrollToLine(targetLine);
+      requestAnimationFrame(() => { syncGuard = false; });
+    }
+  };
+
+  editor.addEventListener('scroll', onEditorScroll, { passive: true });
+  preview.addEventListener('scroll', onPreviewScroll, { passive: true });
+  syncEditorScroll = () => editor.removeEventListener('scroll', onEditorScroll);
+  syncPreviewScroll = () => preview.removeEventListener('scroll', onPreviewScroll);
+}
+
+watch(() => settings.viewMode, async () => {
+  await new Promise((r) => setTimeout(r, 100));
+  bindScrollSync();
+});
+
+watch(() => props.tab?.id, async () => {
+  await new Promise((r) => setTimeout(r, 100));
+  bindScrollSync();
+});
+
+onMounted(() => {
+  setTimeout(bindScrollSync, 300);
+  window.addEventListener('solomd:outline-goto', onOutlineGotoEvent);
+});
+
+onBeforeUnmount(() => {
+  syncEditorScroll?.();
+  syncPreviewScroll?.();
+  window.removeEventListener('solomd:outline-goto', onOutlineGotoEvent);
+});
+
+defineExpose({ gotoLine, editorRef });
+
+function onOutlineGotoEvent(e: Event) {
+  const { line, paneId } = (e as CustomEvent).detail;
+  if (paneId !== props.paneId) return;
+  gotoLine(line);
+}
+</script>
+
+<template>
+  <div class="pane-content">
+    <div class="pane pane--editor" v-if="showEditor && tab">
+      <Editor
+        ref="editorRef"
+        :tab="tab"
+        :focus-mode="settings.focusMode"
+        :typewriter-mode="settings.typewriterMode"
+        :spell-check="settings.spellCheck"
+        @cursor="onCursor"
+      />
+    </div>
+    <div class="pane pane--preview" v-if="showPreview && tab">
+      <Preview
+        ref="previewRef"
+        :source="tab.content"
+        :file-path="tab.filePath"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.pane-content {
+  flex: 1;
+  display: flex;
+  min-width: 0;
+  overflow: hidden;
+}
+.pane {
+  flex: 1;
+  min-width: 0;
+  height: 100%;
+}
+.pane--editor + .pane--preview {
+  border-left: 1px solid var(--border);
+}
+</style>

--- a/app/src/components/PaneHost.vue
+++ b/app/src/components/PaneHost.vue
@@ -107,6 +107,7 @@ function onCursor(line: number, col: number) {
 .pane-host {
   display: flex;
   flex-direction: column;
+  flex: 1;
   min-width: 0;
   min-height: 0;
   overflow: hidden;

--- a/app/src/components/PaneHost.vue
+++ b/app/src/components/PaneHost.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import PaneTabBar from './PaneTabBar.vue';
+import PaneContent from './PaneContent.vue';
+import { useTabsStore } from '../stores/tabs';
+import { useTilesStore } from '../stores/tiles';
+import type { SplitDirection } from '../types';
+
+const props = defineProps<{
+  paneId: string;
+  activeTabId: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'cursor', line: number, col: number): void;
+  (e: 'goto-line', line: number): void;
+}>();
+
+const tabs = useTabsStore();
+const tiles = useTilesStore();
+
+const activeTab = computed(() => tabs.tabs.find((t) => t.id === props.activeTabId));
+const paneContentRef = ref<InstanceType<typeof PaneContent> | null>(null);
+
+// ---- Drop zone for drag-to-split ----
+const dropZone = ref<SplitDirection | null>(null);
+
+function onDragOver(e: DragEvent) {
+  if (!e.dataTransfer) return;
+  e.preventDefault();
+  e.dataTransfer.dropEffect = 'move';
+
+  const target = e.currentTarget as HTMLElement;
+  const rect = target.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const threshold = 50;
+
+  if (x < threshold) dropZone.value = 'horizontal';
+  else if (x > rect.width - threshold) dropZone.value = 'horizontal';
+  else if (y < threshold) dropZone.value = 'vertical';
+  else if (y > rect.height - threshold) dropZone.value = 'vertical';
+  else dropZone.value = null;
+}
+
+function onDragLeave() {
+  dropZone.value = null;
+}
+
+function onDrop(e: DragEvent) {
+  dropZone.value = null;
+  if (!e.dataTransfer) return;
+  const tabId = e.dataTransfer.getData('text/plain');
+  if (!tabId) return;
+
+  const target = e.currentTarget as HTMLElement;
+  const rect = target.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  const threshold = 50;
+
+  let direction: SplitDirection | null = null;
+  if (x < threshold || x > rect.width - threshold) direction = 'horizontal';
+  else if (y < threshold || y > rect.height - threshold) direction = 'vertical';
+
+  if (direction) {
+    tiles.splitPane(props.paneId, direction, tabId);
+  }
+}
+
+function onFocusIn() {
+  tiles.setFocusedPane(props.paneId);
+}
+
+function onCursor(line: number, col: number) {
+  emit('cursor', line, col);
+}
+</script>
+
+<template>
+  <div
+    class="pane-host"
+    :data-pane-id="paneId"
+    :class="{ 'pane-host--focused': tiles.focusedPaneId === paneId }"
+    @focusin="onFocusIn"
+    @click="tiles.setFocusedPane(paneId)"
+    @dragover="onDragOver"
+    @dragleave="onDragLeave"
+    @drop="onDrop"
+  >
+    <PaneTabBar :pane-id="paneId" :active-tab-id="activeTabId" />
+    <PaneContent
+      ref="paneContentRef"
+      :pane-id="paneId"
+      :tab="activeTab"
+      @cursor="onCursor"
+    />
+    <!-- Drop zone overlay indicators -->
+    <div class="drop-zone drop-zone--left" v-if="dropZone === 'horizontal'" />
+    <div class="drop-zone drop-zone--right" v-if="dropZone === 'horizontal'" />
+    <div class="drop-zone drop-zone--top" v-if="dropZone === 'vertical'" />
+    <div class="drop-zone drop-zone--bottom" v-if="dropZone === 'vertical'" />
+  </div>
+</template>
+
+<style scoped>
+.pane-host {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+  background: var(--bg);
+}
+.pane-host--focused {
+  /* subtle indicator for focused pane */
+}
+
+.drop-zone {
+  position: absolute;
+  background: rgba(255, 159, 64, 0.15);
+  pointer-events: none;
+  z-index: 10;
+}
+.drop-zone--left {
+  left: 0; top: 0; bottom: 0; width: 50px;
+  border-right: 2px solid var(--accent);
+}
+.drop-zone--right {
+  right: 0; top: 0; bottom: 0; width: 50px;
+  border-left: 2px solid var(--accent);
+}
+.drop-zone--top {
+  top: 0; left: 0; right: 0; height: 50px;
+  border-bottom: 2px solid var(--accent);
+}
+.drop-zone--bottom {
+  bottom: 0; left: 0; right: 0; height: 50px;
+  border-top: 2px solid var(--accent);
+}
+</style>

--- a/app/src/components/PaneTabBar.vue
+++ b/app/src/components/PaneTabBar.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useTabsStore } from '../stores/tabs';
+import { useTilesStore } from '../stores/tiles';
+import { useFiles } from '../composables/useFiles';
+import type { SplitDirection } from '../types';
+
+const props = defineProps<{
+  paneId: string;
+  activeTabId: string;
+}>();
+
+const tabs = useTabsStore();
+const tiles = useTilesStore();
+const files = useFiles();
+
+// ---- Context menu ----
+const ctxMenu = ref<{ x: number; y: number; tabId: string } | null>(null);
+
+function onContextMenu(e: MouseEvent, tabId: string) {
+  e.preventDefault();
+  ctxMenu.value = { x: e.clientX, y: e.clientY, tabId };
+}
+
+function closeCtxMenu() {
+  ctxMenu.value = null;
+}
+
+function splitPane(direction: SplitDirection) {
+  tiles.splitPane(props.paneId, direction);
+  closeCtxMenu();
+}
+
+function closePane() {
+  tiles.closePane(props.paneId);
+  closeCtxMenu();
+}
+
+// ---- Drag to split ----
+function onDragStart(e: DragEvent, tabId: string) {
+  if (!e.dataTransfer) return;
+  e.dataTransfer.setData('text/plain', tabId);
+  e.dataTransfer.effectAllowed = 'move';
+}
+
+// Close context menu on click outside
+function onDocClick() {
+  if (ctxMenu.value) closeCtxMenu();
+}
+
+import { onMounted, onBeforeUnmount } from 'vue';
+onMounted(() => document.addEventListener('click', onDocClick));
+onBeforeUnmount(() => document.removeEventListener('click', onDocClick));
+</script>
+
+<template>
+  <div class="pane-tabbar">
+    <div class="tabs">
+      <div
+        v-for="t in tabs.tabs"
+        :key="t.id"
+        class="tab"
+        :class="{ 'tab--active': t.id === activeTabId }"
+        @click="tiles.setActiveTab(paneId, t.id)"
+        @contextmenu="onContextMenu($event, t.id)"
+        draggable="true"
+        @dragstart="onDragStart($event, t.id)"
+        :title="t.filePath || t.fileName"
+      >
+        <span class="tab__name">{{ t.fileName }}</span>
+        <span class="tab__dot" v-if="tabs.isDirty(t.id)">●</span>
+        <button
+          class="tab__close"
+          @click.stop="files.closeTabSafe(t.id)"
+          aria-label="Close tab"
+        >×</button>
+      </div>
+    </div>
+    <button class="tabbar__new" @click="files.newFile" title="New tab (Ctrl+N)">+</button>
+
+    <!-- Context menu -->
+    <Teleport to="body">
+      <div
+        v-if="ctxMenu"
+        class="ctx-menu"
+        :style="{ left: ctxMenu.x + 'px', top: ctxMenu.y + 'px' }"
+        @click.stop
+      >
+        <button class="ctx-item" @click="splitPane('horizontal')">Split Right</button>
+        <button class="ctx-item" @click="splitPane('vertical')">Split Down</button>
+        <div class="ctx-sep" v-if="tiles.allLeaves.length > 1" />
+        <button class="ctx-item" v-if="tiles.allLeaves.length > 1" @click="closePane">Close Pane</button>
+      </div>
+    </Teleport>
+  </div>
+</template>
+
+<style scoped>
+.pane-tabbar {
+  display: flex;
+  align-items: stretch;
+  height: var(--tabbar-h);
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  user-select: none;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.tabs {
+  display: flex;
+  flex: 1;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.tabs::-webkit-scrollbar { display: none; }
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 200px;
+  padding: 0 10px 0 14px;
+  border-right: 1px solid var(--border);
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  position: relative;
+}
+.tab:hover {
+  background: var(--bg-hover);
+}
+.tab--active {
+  background: var(--bg);
+  color: var(--text);
+}
+.tab--active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 2px;
+  background: var(--accent);
+}
+.tab__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.tab__dot {
+  color: var(--accent);
+  font-size: 10px;
+}
+.tab__close {
+  padding: 0 4px;
+  font-size: 14px;
+  line-height: 1;
+  color: var(--text-faint);
+  opacity: 0;
+  transition: opacity 0.12s;
+}
+.tab:hover .tab__close,
+.tab--active .tab__close {
+  opacity: 1;
+}
+.tab__close:hover {
+  color: var(--text);
+  background: var(--bg-active);
+}
+.tabbar__new {
+  width: 32px;
+  padding: 0;
+  font-size: 16px;
+  color: var(--text-muted);
+}
+.ctx-menu {
+  position: fixed;
+  z-index: 9999;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 4px 0;
+  min-width: 140px;
+  box-shadow: 0 4px 16px rgba(0,0,0,0.2);
+}
+.ctx-item {
+  display: block;
+  width: 100%;
+  padding: 6px 14px;
+  text-align: left;
+  font-size: 13px;
+  color: var(--text);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.ctx-item:hover {
+  background: var(--bg-hover);
+}
+.ctx-sep {
+  height: 1px;
+  margin: 4px 8px;
+  background: var(--border);
+}
+</style>

--- a/app/src/components/TileDivider.vue
+++ b/app/src/components/TileDivider.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useTilesStore } from '../stores/tiles';
+import type { SplitDirection } from '../types';
+
+const props = defineProps<{
+  branchId: string;
+  direction: SplitDirection;
+}>();
+
+const tiles = useTilesStore();
+const active = ref(false);
+
+function onMouseDown(e: MouseEvent) {
+  e.preventDefault();
+  active.value = true;
+
+  const startPos = props.direction === 'horizontal' ? e.clientX : e.clientY;
+  const startSizes = (() => {
+    const node = findBranch();
+    return node ? [...node.sizes] as [number, number] : [50, 50] as [number, number];
+  })();
+
+  // Get the branch container dimensions
+  const container = (e.target as HTMLElement).parentElement;
+  const totalSize = container
+    ? (props.direction === 'horizontal' ? container.clientWidth : container.clientHeight) - 4 // minus divider width
+    : 1000;
+
+  function onMove(ev: MouseEvent) {
+    const currentPos = props.direction === 'horizontal' ? ev.clientX : ev.clientY;
+    const delta = currentPos - startPos;
+    const deltaPercent = (delta / totalSize) * 100;
+    const newSizes: [number, number] = [
+      startSizes[0] + deltaPercent,
+      startSizes[1] - deltaPercent,
+    ];
+    tiles.setSizes(props.branchId, newSizes);
+  }
+
+  function onUp() {
+    active.value = false;
+    document.removeEventListener('mousemove', onMove);
+    document.removeEventListener('mouseup', onUp);
+  }
+
+  document.addEventListener('mousemove', onMove);
+  document.addEventListener('mouseup', onUp);
+}
+
+function findBranch() {
+  function walk(node: any): any {
+    if (node.id === props.branchId) return node;
+    if (node.type === 'leaf') return null;
+    return walk(node.children[0]) ?? walk(node.children[1]);
+  }
+  return walk(tiles.root);
+}
+</script>
+
+<template>
+  <div
+    class="tile-divider"
+    :class="[
+      `tile-divider--${direction}`,
+      { 'tile-divider--active': active }
+    ]"
+    @mousedown="onMouseDown"
+  />
+</template>
+
+<style scoped>
+.tile-divider {
+  flex-shrink: 0;
+  background: var(--border);
+  transition: background 0.15s;
+}
+.tile-divider:hover,
+.tile-divider--active {
+  background: var(--accent);
+}
+.tile-divider--horizontal {
+  width: 4px;
+  cursor: col-resize;
+}
+.tile-divider--vertical {
+  height: 4px;
+  cursor: row-resize;
+}
+</style>

--- a/app/src/components/TileRoot.vue
+++ b/app/src/components/TileRoot.vue
@@ -65,6 +65,7 @@ const emit = defineEmits<{
   flex-direction: column;
 }
 .tile-child {
+  display: flex;
   min-width: 0;
   min-height: 0;
   overflow: hidden;

--- a/app/src/components/TileRoot.vue
+++ b/app/src/components/TileRoot.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import PaneHost from './PaneHost.vue';
+import TileDivider from './TileDivider.vue';
+import type { TileNode } from '../types';
+
+defineProps<{
+  node: TileNode;
+}>();
+
+const emit = defineEmits<{
+  (e: 'cursor', line: number, col: number): void;
+  (e: 'goto-line', paneId: string, line: number): void;
+}>();
+</script>
+
+<template>
+  <!-- Leaf: render a single pane host -->
+  <PaneHost
+    v-if="node.type === 'leaf'"
+    :pane-id="node.id"
+    :active-tab-id="node.activeTabId"
+    @cursor="(l, c) => emit('cursor', l, c)"
+  />
+
+  <!-- Branch: flex container with two children and a divider -->
+  <div
+    v-else
+    class="tile-branch"
+    :class="`tile-branch--${node.direction}`"
+  >
+    <div
+      class="tile-child"
+      :style="{ flex: `0 0 ${node.sizes[0]}%` }"
+    >
+      <TileRoot
+        :node="node.children[0]"
+        @cursor="(l: number, c: number) => emit('cursor', l, c)"
+      />
+    </div>
+    <TileDivider
+      :branch-id="node.id"
+      :direction="node.direction"
+    />
+    <div class="tile-child" style="flex: 1; min-width: 0; min-height: 0;">
+      <TileRoot
+        :node="node.children[1]"
+        @cursor="(l: number, c: number) => emit('cursor', l, c)"
+      />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tile-branch {
+  display: flex;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  flex: 1;
+}
+.tile-branch--horizontal {
+  flex-direction: row;
+}
+.tile-branch--vertical {
+  flex-direction: column;
+}
+.tile-child {
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+</style>

--- a/app/src/composables/useCommands.ts
+++ b/app/src/composables/useCommands.ts
@@ -1,6 +1,7 @@
 import { useFiles } from './useFiles';
 import { useSettingsStore } from '../stores/settings';
 import { useTabsStore } from '../stores/tabs';
+import { useTilesStore } from '../stores/tiles';
 import { useExport } from './useExport';
 import { useToastsStore } from '../stores/toasts';
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow';
@@ -25,6 +26,7 @@ export function useCommands(): Command[] {
   const files = useFiles();
   const settings = useSettingsStore();
   const tabs = useTabsStore();
+  const tiles = useTilesStore();
   const exporter = useExport();
   const toasts = useToastsStore();
 
@@ -67,6 +69,13 @@ export function useCommands(): Command[] {
     { id: 'view.toggleSpellCheck', title: 'View: Toggle Spell Check', run: () => settings.toggleSpellCheck() },
     { id: 'view.toggleFocusMode', title: 'View: Toggle Focus Mode', run: () => settings.toggleFocusMode() },
     { id: 'view.toggleTypewriter', title: 'View: Toggle Typewriter Mode', run: () => settings.toggleTypewriterMode() },
+
+    // ---- Tile layout ----
+    { id: 'tile.splitRight', title: 'Split Editor Right', shortcut: 'Ctrl+\\', run: () => tiles.splitPane(tiles.focusedPaneId, 'horizontal') },
+    { id: 'tile.splitDown', title: 'Split Editor Down', shortcut: 'Ctrl+Shift+\\', run: () => tiles.splitPane(tiles.focusedPaneId, 'vertical') },
+    { id: 'tile.closePane', title: 'Close Pane', run: () => tiles.closePane(tiles.focusedPaneId) },
+    { id: 'tile.focusNext', title: 'Focus Next Pane', shortcut: 'Ctrl+Alt+Right', run: () => tiles.focusNextPane() },
+    { id: 'tile.focusPrev', title: 'Focus Previous Pane', shortcut: 'Ctrl+Alt+Left', run: () => tiles.focusPrevPane() },
 
     {
       id: 'search.global',

--- a/app/src/composables/useShortcuts.ts
+++ b/app/src/composables/useShortcuts.ts
@@ -3,6 +3,7 @@ import { useFiles } from './useFiles';
 import { useExport } from './useExport';
 import { useSettingsStore } from '../stores/settings';
 import { useTabsStore } from '../stores/tabs';
+import { useTilesStore } from '../stores/tiles';
 import { useCommands } from './useCommands';
 
 interface Hooks {
@@ -17,6 +18,7 @@ export function useShortcuts(hooks: Hooks = {}) {
   const exporter = useExport();
   const settings = useSettingsStore();
   const tabs = useTabsStore();
+  const tiles = useTilesStore();
   const commands = useCommands();
 
   function runById(id: string) {
@@ -92,6 +94,27 @@ export function useShortcuts(hooks: Hooks = {}) {
     } else if (k === 'b') {
       e.preventDefault();
       settings.toggleFileTree();
+    }
+
+    // Tile layout shortcuts
+    if (e.key === '\\') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        tiles.splitPane(tiles.focusedPaneId, 'vertical');
+      } else {
+        tiles.splitPane(tiles.focusedPaneId, 'horizontal');
+      }
+      return;
+    }
+    if (k === 'arrowright' && e.altKey) {
+      e.preventDefault();
+      tiles.focusNextPane();
+      return;
+    }
+    if (k === 'arrowleft' && e.altKey) {
+      e.preventDefault();
+      tiles.focusPrevPane();
+      return;
     }
   }
 

--- a/app/src/stores/tabs.ts
+++ b/app/src/stores/tabs.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia';
 import type { Language, Tab } from '../types';
 import { useSettingsStore } from './settings';
+import { useTilesStore } from './tiles';
 
 const LS_KEY = 'solomd.tabs.v1';
 
@@ -112,6 +113,11 @@ export const useTabsStore = defineStore('tabs', {
       if (this.activeId === id) {
         this.activeId = this.tabs[idx]?.id ?? this.tabs[idx - 1]?.id ?? '';
       }
+      // Clean up any pane references to the closed tab
+      try {
+        const tiles = useTilesStore();
+        tiles.removePaneReferences(id);
+      } catch {}
       if (this.tabs.length === 0) this.newTab();
     },
     activate(id: string) {

--- a/app/src/stores/tiles.ts
+++ b/app/src/stores/tiles.ts
@@ -1,0 +1,251 @@
+import { defineStore } from 'pinia';
+import type { SplitDirection, TileBranch, TileLeaf, TileNode } from '../types';
+import { useTabsStore } from './tabs';
+
+const LS_KEY = 'solomd.tiles.v1';
+
+let nextPaneId = 0;
+const newPaneId = () => `pane-${Date.now()}-${nextPaneId++}`;
+const newBranchId = () => `branch-${Date.now()}-${nextPaneId++}`;
+
+interface PersistedState {
+  root: TileNode;
+  focusedPaneId: string;
+}
+
+function loadPersisted(): PersistedState | null {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (raw) {
+      const data = JSON.parse(raw) as PersistedState;
+      if (data.root) return data;
+    }
+  } catch {}
+  return null;
+}
+
+// ---- Tree helpers ----
+
+function collectLeaves(node: TileNode): TileLeaf[] {
+  if (node.type === 'leaf') return [node];
+  return [...collectLeaves(node.children[0]), ...collectLeaves(node.children[1])];
+}
+
+function findNode(root: TileNode, id: string): TileNode | null {
+  if (root.id === id) return root;
+  if (root.type === 'leaf') return null;
+  return findNode(root.children[0], id) ?? findNode(root.children[1], id);
+}
+
+function findLeaf(root: TileNode, paneId: string): TileLeaf | null {
+  const node = findNode(root, paneId);
+  return node?.type === 'leaf' ? node : null;
+}
+
+function findParent(root: TileNode, id: string): { parent: TileBranch; index: 0 | 1 } | null {
+  if (root.type === 'leaf') return null;
+  for (let i = 0 as 0 | 1; i <= 1; i++) {
+    if (root.children[i].id === id) return { parent: root, index: i };
+    const found = findParent(root.children[i], id);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Replace a node in the tree by id, returning a new tree (immutable). */
+function replaceNode(root: TileNode, targetId: string, replacement: TileNode): TileNode {
+  if (root.id === targetId) return replacement;
+  if (root.type === 'leaf') return root;
+  return {
+    ...root,
+    children: [
+      replaceNode(root.children[0], targetId, replacement),
+      replaceNode(root.children[1], targetId, replacement),
+    ] as [TileNode, TileNode],
+  };
+}
+
+function firstLeaf(node: TileNode): TileLeaf {
+  if (node.type === 'leaf') return node;
+  return firstLeaf(node.children[0]);
+}
+
+export const useTilesStore = defineStore('tiles', {
+  state: (): PersistedState => {
+    const saved = loadPersisted();
+    if (saved) return saved;
+    // Default: single leaf with empty activeTabId (will be set on init)
+    const defaultLeaf: TileLeaf = { type: 'leaf', id: newPaneId(), activeTabId: '' };
+    return { root: defaultLeaf, focusedPaneId: defaultLeaf.id };
+  },
+
+  getters: {
+    allLeaves(state): TileLeaf[] {
+      return collectLeaves(state.root);
+    },
+    focusedLeaf(state): TileLeaf | null {
+      return findLeaf(state.root, state.focusedPaneId);
+    },
+    leafForPane(): (paneId: string) => TileLeaf | null {
+      return (paneId: string) => findLeaf(this.root, paneId);
+    },
+  },
+
+  actions: {
+    initDefault(tabId: string) {
+      const leaf: TileLeaf = { type: 'leaf', id: newPaneId(), activeTabId: tabId };
+      this.root = leaf;
+      this.focusedPaneId = leaf.id;
+    },
+
+    splitPane(paneId: string, direction: SplitDirection, newTabId?: string) {
+      const leaf = findLeaf(this.root, paneId);
+      if (!leaf) return;
+
+      const child0: TileLeaf = { type: 'leaf', id: leaf.id, activeTabId: leaf.activeTabId };
+      const child1: TileLeaf = {
+        type: 'leaf',
+        id: newPaneId(),
+        activeTabId: newTabId ?? leaf.activeTabId,
+      };
+      const branch: TileBranch = {
+        type: 'branch',
+        id: newBranchId(),
+        direction,
+        sizes: [50, 50],
+        children: [child0, child1],
+      };
+
+      this.root = replaceNode(this.root, paneId, branch);
+      this.focusedPaneId = child1.id;
+      this.syncActiveTab();
+    },
+
+    closePane(paneId: string) {
+      const leaves = collectLeaves(this.root);
+      if (leaves.length <= 1) return; // always keep at least one pane
+
+      const parentInfo = findParent(this.root, paneId);
+      if (!parentInfo) return;
+
+      const { parent, index } = parentInfo;
+      const sibling = parent.children[1 - index];
+
+      if (this.root.id === parent.id) {
+        this.root = sibling;
+      } else {
+        this.root = replaceNode(this.root, parent.id, sibling);
+      }
+
+      // Focus the first leaf of the sibling subtree
+      this.focusedPaneId = firstLeaf(sibling).id;
+      this.syncActiveTab();
+    },
+
+    setActiveTab(paneId: string, tabId: string) {
+      const leaf = findLeaf(this.root, paneId);
+      if (!leaf) return;
+      const newLeaf: TileLeaf = { ...leaf, activeTabId: tabId };
+      this.root = replaceNode(this.root, paneId, newLeaf);
+      this.focusedPaneId = paneId;
+      this.syncActiveTab();
+    },
+
+    /** Sync tabs.activeId to the focused pane without triggering syncActiveTab (avoids loops). */
+    syncFromTabs(tabId: string) {
+      if (!tabId) return;
+      const leaf = findLeaf(this.root, this.focusedPaneId);
+      if (leaf && leaf.activeTabId !== tabId) {
+        const newLeaf: TileLeaf = { ...leaf, activeTabId: tabId };
+        this.root = replaceNode(this.root, leaf.id, newLeaf);
+      }
+    },
+
+    setFocusedPane(paneId: string) {
+      this.focusedPaneId = paneId;
+      this.syncActiveTab();
+    },
+
+    setSizes(branchId: string, sizes: [number, number]) {
+      const node = findNode(this.root, branchId);
+      if (!node || node.type !== 'branch') return;
+      const clamped: [number, number] = [
+        Math.max(10, Math.min(90, sizes[0])),
+        0,
+      ];
+      clamped[1] = 100 - clamped[0];
+      const updated: TileBranch = { ...node, sizes: clamped };
+      this.root = replaceNode(this.root, branchId, updated);
+    },
+
+    removePaneReferences(tabId: string) {
+      const tabs = useTabsStore();
+      const leaves = collectLeaves(this.root);
+      let changed = false;
+      for (const leaf of leaves) {
+        if (leaf.activeTabId !== tabId) continue;
+        const other = tabs.tabs.find((t) => t.id !== tabId);
+        const newLeaf: TileLeaf = { ...leaf, activeTabId: other?.id ?? '' };
+        this.root = replaceNode(this.root, leaf.id, newLeaf);
+        changed = true;
+      }
+      if (changed) this.syncActiveTab();
+    },
+
+    syncActiveTab() {
+      const tabs = useTabsStore();
+      const leaf = findLeaf(this.root, this.focusedPaneId);
+      if (leaf?.activeTabId) {
+        tabs.activeId = leaf.activeTabId;
+      }
+    },
+
+    focusNextPane() {
+      const leaves = collectLeaves(this.root);
+      if (leaves.length <= 1) return;
+      const idx = leaves.findIndex((l) => l.id === this.focusedPaneId);
+      const next = leaves[(idx + 1) % leaves.length];
+      this.focusedPaneId = next.id;
+      this.syncActiveTab();
+    },
+
+    focusPrevPane() {
+      const leaves = collectLeaves(this.root);
+      if (leaves.length <= 1) return;
+      const idx = leaves.findIndex((l) => l.id === this.focusedPaneId);
+      const prev = leaves[(idx - 1 + leaves.length) % leaves.length];
+      this.focusedPaneId = prev.id;
+      this.syncActiveTab();
+    },
+
+    persist() {
+      try {
+        localStorage.setItem(LS_KEY, JSON.stringify({ root: this.root, focusedPaneId: this.focusedPaneId }));
+      } catch {}
+    },
+
+    /** Validate persisted state: ensure all activeTabIds reference existing tabs. */
+    validate(tabs: { id: string }[]) {
+      const ids = new Set(tabs.map((t) => t.id));
+      let changed = false;
+      const fix = (node: TileNode): TileNode => {
+        if (node.type === 'leaf') {
+          if (node.activeTabId && !ids.has(node.activeTabId)) {
+            changed = true;
+            return { ...node, activeTabId: tabs[0]?.id ?? '' };
+          }
+          return node;
+        }
+        return { ...node, children: [fix(node.children[0]), fix(node.children[1])] as [TileNode, TileNode] };
+      };
+      this.root = fix(this.root);
+      // Fix focusedPaneId
+      const leafIds = new Set(collectLeaves(this.root).map((l) => l.id));
+      if (!leafIds.has(this.focusedPaneId)) {
+        this.focusedPaneId = firstLeaf(this.root).id;
+        changed = true;
+      }
+      if (changed) this.syncActiveTab();
+    },
+  },
+});

--- a/app/src/types.ts
+++ b/app/src/types.ts
@@ -28,3 +28,23 @@ export interface FileReadResult {
   language: Language;
   had_bom: boolean;
 }
+
+// ---- Tile layout (split editor) ----
+
+export type SplitDirection = 'horizontal' | 'vertical';
+
+export interface TileLeaf {
+  type: 'leaf';
+  id: string;
+  activeTabId: string;
+}
+
+export interface TileBranch {
+  type: 'branch';
+  id: string;
+  direction: SplitDirection;
+  sizes: [number, number]; // percentages summing to 100
+  children: [TileNode, TileNode];
+}
+
+export type TileNode = TileLeaf | TileBranch;


### PR DESCRIPTION
  - 分屏编辑：支持将编辑区域拆分为多个面板，可水平（左右）或垂直（上下）并排查看多个文档
  - 三种触发方式：右键标签页菜单（Split Right / Split Down）、键盘快捷键（Ctrl+\ / Ctrl+Shift+\）、拖拽标签页到面板边缘
  - 可拖拽调整大小：面板间有拖拽手柄，实时调整分割比例（最小 10%）
  - 布局持久化：分屏状态保存到 localStorage，重启后恢复
  - 每个面板拥有独立的标签栏、编辑器和预览，支持同一文档在多个面板中同时查看

  New files

  - stores/tiles.ts — 递归树状数据结构，管理分屏布局的 split/close/focus/resize/persist
  - TileRoot.vue — 递归渲染器，将树结构映射为 flex 布局
  - PaneHost.vue — 单面板容器，含拖放区域
  - PaneTabBar.vue — 面板级标签栏，含右键菜单和拖拽
  - PaneContent.vue — 从 App.vue 提取的编辑器+预览，面板内滚动同步
  - TileDivider.vue — 可拖拽的 4px 分割手柄

  Keyboard shortcuts

  ┌──────────────┬─────────────────────┐
  │   Shortcut   │       Action        │
  ├──────────────┼─────────────────────┤
  │ Ctrl+\       │ Split Right         │
  ├──────────────┼─────────────────────┤
  │ Ctrl+Shift+\ │ Split Down          │
  ├──────────────┼─────────────────────┤
  │ Ctrl+Alt+→   │ Focus Next Pane     │
  ├──────────────┼─────────────────────┤
  │ Ctrl+Alt+←   │ Focus Previous Pane │
  └──────────────┴─────────────────────┘