### PR TITLE
预览模式搜索 + 工具栏图标优化

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -419,7 +419,7 @@ const showOutlinePane = computed(
 }
 .outline-toggle {
   position: absolute;
-  top: 6px;
+  top: calc(var(--tabbar-h, 34px) + 6px);
   left: 6px;
   z-index: 10;
   padding: 4px 6px;

--- a/app/src/components/Icons.vue
+++ b/app/src/components/Icons.vue
@@ -64,8 +64,8 @@ defineProps<{ name: string; size?: number }>();
       <line x1="3" y1="18" x2="3.01" y2="18" />
     </template>
     <template v-else-if="name === 'palette'">
-      <circle cx="11" cy="11" r="8" />
-      <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      <polyline points="4 17 10 11 4 5" />
+      <line x1="12" y1="19" x2="20" y2="19" />
     </template>
     <template v-else-if="name === 'help'">
       <circle cx="12" cy="12" r="10" />

--- a/app/src/components/Icons.vue
+++ b/app/src/components/Icons.vue
@@ -34,10 +34,11 @@ defineProps<{ name: string; size?: number }>();
       <polyline points="7 3 7 8 15 8" />
     </template>
     <template v-else-if="name === 'save-as'">
-      <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
-      <polyline points="17 21 17 13 7 13 7 21" />
-      <line x1="12" y1="3" x2="12" y2="8" />
-      <polyline points="9 5 12 2 15 5" />
+      <rect x="3" y="3" width="13" height="13" rx="1" />
+      <polyline points="13 3 13 8 5 8" />
+      <rect x="8" y="12" width="13" height="9" rx="1" fill="var(--bg)" stroke="currentColor" />
+      <polyline points="18 12 18 16 11 16" />
+      <line x1="11" y1="19" x2="18" y2="19" />
     </template>
     <template v-else-if="name === 'folder'">
       <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />

--- a/app/src/components/PaneContent.vue
+++ b/app/src/components/PaneContent.vue
@@ -151,6 +151,7 @@ onMounted(() => {
   setTimeout(bindScrollSync, 300);
   window.addEventListener('solomd:outline-goto', onOutlineGotoEvent);
   window.addEventListener('solomd:insert-markdown', onInsertMarkdownEvent);
+  window.addEventListener('solomd:preview-search', onPreviewSearchEvent);
 });
 
 onBeforeUnmount(() => {
@@ -158,6 +159,7 @@ onBeforeUnmount(() => {
   syncPreviewScroll?.();
   window.removeEventListener('solomd:outline-goto', onOutlineGotoEvent);
   window.removeEventListener('solomd:insert-markdown', onInsertMarkdownEvent);
+  window.removeEventListener('solomd:preview-search', onPreviewSearchEvent);
 });
 
 defineExpose({ gotoLine, editorRef });
@@ -173,6 +175,12 @@ function onInsertMarkdownEvent(e: Event) {
   if (paneId !== props.paneId) return;
   const ed = editorRef.value as unknown as { insertMarkdown?: (s: string) => void } | null;
   ed?.insertMarkdown?.(snippet);
+}
+
+function onPreviewSearchEvent(e: Event) {
+  const { paneId } = (e as CustomEvent).detail;
+  if (paneId !== props.paneId) return;
+  (previewRef.value as unknown as { openSearch?: () => void } | null)?.openSearch?.();
 }
 </script>
 

--- a/app/src/components/Preview.vue
+++ b/app/src/components/Preview.vue
@@ -7,11 +7,14 @@ import { renderMarkdown, extractImageRoot } from '../lib/markdown';
 import { openImageOverlay, type OverlayStrings } from '../lib/image-overlay';
 import { useI18n } from '../i18n';
 import { useSettingsStore } from '../stores/settings';
+import PreviewSearch from './PreviewSearch.vue';
 
 const props = defineProps<{ source: string; filePath?: string }>();
 const settings = useSettingsStore();
 const { t } = useI18n();
 const host = ref<HTMLDivElement | null>(null);
+const searchOpen = ref(false);
+const searchRef = ref<InstanceType<typeof PreviewSearch> | null>(null);
 
 let mermaidIdSeq = 0;
 
@@ -189,6 +192,11 @@ onBeforeUnmount(() => {
   host.value?.removeEventListener('click', handleLinkClick);
 });
 
+function openSearch() {
+  searchOpen.value = true;
+  nextTick(() => searchRef.value?.focusInput());
+}
+
 /**
  * Scroll the preview pane so the element tagged with `data-source-line="N"`
  * (where N is the nearest line ≤ the requested line) is brought to the top.
@@ -225,11 +233,17 @@ function scrollToLine(line: number) {
   container.scrollTo({ top: offset, behavior: 'smooth' });
 }
 
-defineExpose({ scrollToLine });
+defineExpose({ scrollToLine, openSearch });
 </script>
 
 <template>
   <div class="preview-host">
+    <PreviewSearch
+      v-if="searchOpen && host"
+      ref="searchRef"
+      :container="host"
+      @close="searchOpen = false"
+    />
     <article ref="host" class="preview-content" :class="{ 'preview-content--fit': settings.previewFitWidth }" v-html="html"></article>
   </div>
 </template>
@@ -365,5 +379,16 @@ defineExpose({ scrollToLine });
   overflow-x: auto;
   overflow-y: hidden;
   margin: 1em 0;
+}
+/* Preview search highlights */
+.preview-content .ps-mark {
+  background: rgba(255, 159, 64, 0.3);
+  color: inherit;
+  padding: 1px 0;
+  border-radius: 2px;
+}
+.preview-content .ps-mark--current {
+  background: var(--accent);
+  color: var(--accent-fg, #fff);
 }
 </style>

--- a/app/src/components/PreviewSearch.vue
+++ b/app/src/components/PreviewSearch.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+import { ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue';
+import { useI18n } from '../i18n';
+
+const props = defineProps<{ container: HTMLElement }>();
+const emit = defineEmits<{ (e: 'close'): void }>();
+
+const { t } = useI18n();
+
+const inputRef = ref<HTMLInputElement | null>(null);
+const query = ref('');
+const matchCount = ref(0);
+const currentIdx = ref(0);
+
+let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+let observer: MutationObserver | null = null;
+
+function pauseObserver() {
+  observer?.disconnect();
+}
+
+function resumeObserver() {
+  if (!observer || !props.container) return;
+  observer.observe(props.container, { childList: true, subtree: true });
+}
+
+function clearMarks() {
+  if (!props.container) return;
+  pauseObserver();
+  const marks = props.container.querySelectorAll<HTMLElement>('mark.ps-mark');
+  for (const mark of Array.from(marks)) {
+    const parent = mark.parentNode;
+    if (!parent) continue;
+    parent.replaceChild(document.createTextNode(mark.textContent || ''), mark);
+  }
+  props.container.normalize();
+  matchCount.value = 0;
+  currentIdx.value = 0;
+  resumeObserver();
+}
+
+function doSearch() {
+  clearMarks();
+  const q = query.value.trim();
+  if (!q || !props.container) return;
+
+  pauseObserver();
+
+  const lower = q.toLowerCase();
+  const walker = document.createTreeWalker(
+    props.container,
+    NodeFilter.SHOW_TEXT,
+    null,
+  );
+
+  // Collect match positions grouped by text node.
+  const byNode = new Map<Text, Array<{ start: number; end: number }>>();
+  let total = 0;
+  let node: Text | null;
+  while ((node = walker.nextNode() as Text | null)) {
+    const text = node.textContent || '';
+    const lowerText = text.toLowerCase();
+    let pos = 0;
+    const hits: Array<{ start: number; end: number }> = [];
+    while ((pos = lowerText.indexOf(lower, pos)) !== -1) {
+      hits.push({ start: pos, end: pos + q.length });
+      pos += 1;
+    }
+    if (hits.length > 0) {
+      byNode.set(node, hits);
+      total += hits.length;
+    }
+  }
+
+  if (total > 0) {
+    // Apply highlights per node, descending by offset to avoid shifts.
+    for (const [textNode, hits] of byNode) {
+      const sorted = [...hits].sort((a, b) => b.start - a.start);
+      for (const { start, end } of sorted) {
+        const range = document.createRange();
+        range.setStart(textNode, start);
+        range.setEnd(textNode, end);
+        const mark = document.createElement('mark');
+        mark.className = 'ps-mark';
+        range.surroundContents(mark);
+      }
+    }
+    matchCount.value = total;
+    currentIdx.value = 0;
+  }
+
+  resumeObserver();
+
+  if (total > 0) highlightCurrent();
+}
+
+function highlightCurrent() {
+  if (!props.container) return;
+  const marks = props.container.querySelectorAll<HTMLElement>('mark.ps-mark');
+  marks.forEach((m, i) => {
+    m.classList.toggle('ps-mark--current', i === currentIdx.value);
+  });
+  const current = marks[currentIdx.value];
+  if (current) {
+    current.scrollIntoView({ block: 'center', behavior: 'smooth' });
+  }
+}
+
+function goNext() {
+  if (matchCount.value === 0) return;
+  currentIdx.value = (currentIdx.value + 1) % matchCount.value;
+  highlightCurrent();
+}
+
+function goPrev() {
+  if (matchCount.value === 0) return;
+  currentIdx.value = (currentIdx.value - 1 + matchCount.value) % matchCount.value;
+  highlightCurrent();
+}
+
+function onInput() {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(doSearch, 150);
+}
+
+function onKeydown(e: KeyboardEvent) {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+    if (e.shiftKey) goPrev(); else goNext();
+  } else if (e.key === 'Escape') {
+    e.preventDefault();
+    close();
+  }
+}
+
+function close() {
+  clearMarks();
+  query.value = '';
+  emit('close');
+}
+
+function setupObserver() {
+  if (observer) observer.disconnect();
+  observer = new MutationObserver(() => {
+    if (query.value.trim()) {
+      nextTick(doSearch);
+    }
+  });
+  observer.observe(props.container, { childList: true, subtree: true });
+}
+
+watch(() => props.container, (el) => {
+  if (el) setupObserver();
+});
+
+onMounted(() => {
+  nextTick(() => {
+    inputRef.value?.focus();
+    if (props.container) setupObserver();
+  });
+});
+
+onBeforeUnmount(() => {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  observer?.disconnect();
+  clearMarks();
+});
+
+function focusInput() {
+  inputRef.value?.focus();
+}
+
+defineExpose({ focusInput });
+</script>
+
+<template>
+  <div class="ps-bar" @click.stop @mousedown.stop>
+    <input
+      ref="inputRef"
+      class="ps-input"
+      type="text"
+      :placeholder="t('previewSearchPlaceholder')"
+      v-model="query"
+      @input="onInput"
+      @keydown="onKeydown"
+    />
+    <span class="ps-count" v-if="query.trim()">
+      {{ matchCount > 0 ? `${currentIdx + 1}/${matchCount}` : t('noResults') }}
+    </span>
+    <button class="ps-btn" :disabled="matchCount === 0" @click="goPrev" title="Previous">&#9650;</button>
+    <button class="ps-btn" :disabled="matchCount === 0" @click="goNext" title="Next">&#9660;</button>
+    <button class="ps-btn ps-btn--close" @click="close" title="Close">&#10005;</button>
+  </div>
+</template>
+
+<style scoped>
+.ps-bar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  background: var(--bg-elev);
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-ui);
+}
+.ps-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  font: 14px var(--font-ui);
+  color: var(--text);
+  min-width: 0;
+}
+.ps-input::placeholder {
+  color: var(--text-faint);
+}
+.ps-count {
+  font-size: 12px;
+  color: var(--text-faint);
+  white-space: nowrap;
+  min-width: 40px;
+  text-align: right;
+}
+.ps-btn {
+  padding: 2px 6px;
+  border: none;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--text-muted);
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+.ps-btn:hover:not(:disabled) {
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.ps-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.ps-btn--close {
+  font-size: 14px;
+  padding: 2px 4px;
+}
+</style>

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -375,6 +375,7 @@ onBeforeUnmount(() => {
     <div class="toolbar__group">
       <button
         class="icon-btn"
+        :disabled="settings.viewMode === 'preview'"
         @click="settings.toggleFocusMode"
         :class="{ active: settings.focusMode }"
         :title="t('toolbar.focusModeTooltip')"
@@ -383,6 +384,7 @@ onBeforeUnmount(() => {
       </button>
       <button
         class="icon-btn"
+        :disabled="settings.viewMode === 'preview'"
         @click="settings.toggleTypewriterMode"
         :class="{ active: settings.typewriterMode }"
         :title="t('toolbar.typewriterTooltip')"
@@ -391,6 +393,7 @@ onBeforeUnmount(() => {
       </button>
       <button
         class="icon-btn"
+        :disabled="settings.viewMode === 'preview'"
         @click="settings.toggleSpellCheck"
         :class="{ active: settings.spellCheck }"
         :title="t('toolbar.spellCheckTooltip')"
@@ -466,6 +469,13 @@ onBeforeUnmount(() => {
 }
 .icon-btn:hover {
   color: var(--text);
+}
+.icon-btn:disabled {
+  opacity: 0.3;
+  cursor: default;
+}
+.icon-btn:disabled:hover {
+  color: var(--text-muted);
 }
 .clean-ai-btn {
   position: relative;

--- a/app/src/composables/useShortcuts.ts
+++ b/app/src/composables/useShortcuts.ts
@@ -91,6 +91,13 @@ export function useShortcuts(hooks: Hooks = {}) {
     } else if (k === 'f' && e.shiftKey) {
       e.preventDefault();
       hooks.openGlobalSearch?.();
+    } else if (k === 'f' && !e.shiftKey) {
+      if (settings.viewMode === 'preview' && tabs.activeTab?.language === 'markdown') {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent('solomd:preview-search', {
+          detail: { paneId: tiles.focusedPaneId },
+        }));
+      }
     } else if (k === 'b') {
       e.preventDefault();
       settings.toggleFileTree();

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -67,6 +67,8 @@ export const en = {
     outline: 'Outline',
     fileTree: 'File tree',
     search: 'Search',
+    previewSearchPlaceholder: 'Find in preview…',
+    noResults: 'No results',
     edit: 'Edit',
     split: 'Split',
     preview: 'Preview',

--- a/app/src/i18n/zh.ts
+++ b/app/src/i18n/zh.ts
@@ -69,6 +69,8 @@ export const zh: I18n = {
     outline: '大纲',
     fileTree: '文件树',
     search: '搜索',
+    previewSearchPlaceholder: '在预览中查找…',
+    noResults: '无匹配结果',
     edit: '编辑',
     split: '分栏',
     preview: '预览',


### PR DESCRIPTION
  - 预览模式搜索: 新增 PreviewSearch 组件，预览模式下按 Ctrl+F 可搜索渲染后的 Markdown 内容，支持高亮匹配、上下导航（Enter/Shift+Enter）、匹配计数显示
  - 工具栏图标区分: 命令面板图标改为终端提示符 >_（避免与搜索放大镜重复）；Save As 图标改为双软盘重叠（与 Save 明确区分）
  - 工具栏状态修正: 预览模式下 disable 专注模式/打字机/拼写检查按钮；大纲切换按钮位置下移至标签栏下方