### PR TITLE
Carry v2.3.1 FileTree fix + version bump into main

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solomd",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.3.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "async-stream",
  "calamine",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solomd"
-version = "2.3.0"
+version = "2.3.1"
 description = "SoloMD — a lightweight, cross-platform Markdown + plain text editor"
 authors = ["zhitong"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SoloMD",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "identifier": "app.solomd",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/src/components/FileTree.vue
+++ b/app/src/components/FileTree.vue
@@ -61,22 +61,26 @@ async function refreshRoot() {
     return;
   }
   const path = workspace.currentFolder;
-  const node: Node = {
+  // Phase 1: show "Loading…" immediately so a slow filesystem (Windows
+  // OneDrive, network mounts) doesn't render as an empty pane.
+  root.value = {
     name: path.split(/[\\/]/).pop() ?? path,
     path,
     is_dir: true,
     expanded: true,
     loading: true,
   };
-  // Set immediately so the user sees a Loading row instead of an
-  // empty pane while a slow filesystem (Windows OneDrive, network
-  // mounts) churns through the dir scan.
-  root.value = node;
+  // Phase 2: load children, then mutate through the existing proxy so
+  // Vue picks up the change. (Re-assigning the same raw `node` object
+  // back into `root.value` after mutating it externally is a no-op —
+  // ref's setter checks identity. Going through `root.value.x = y`
+  // routes through the reactive proxy and does trigger updates.)
   const { children, truncated } = await loadDir(path);
-  node.children = children;
-  node.truncated = truncated;
-  node.loading = false;
-  root.value = node;
+  if (root.value) {
+    root.value.children = children;
+    root.value.truncated = truncated;
+    root.value.loading = false;
+  }
 }
 
 async function toggle(node: Node) {

--- a/web/src/components/Download.astro
+++ b/web/src/components/Download.astro
@@ -4,7 +4,7 @@ interface Props { lang: Lang }
 const { lang } = Astro.props;
 const tr = getT(lang);
 
-const VERSION = '2.3.0';
+const VERSION = '2.3.1';
 const REPO = 'zhitongblog/solomd';
 const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
 

--- a/web/src/components/Hero.astro
+++ b/web/src/components/Hero.astro
@@ -4,7 +4,7 @@ interface Props { lang: Lang }
 const { lang } = Astro.props;
 const tr = getT(lang);
 
-const VERSION = '2.3.0';
+const VERSION = '2.3.1';
 const REPO = 'zhitongblog/solomd';
 const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
 const whatsNewHref = lang === 'zh' ? '/zh/whats-new/' : '/whats-new/';


### PR DESCRIPTION
## Summary

- v2.3.1 was tagged off `v2.3.0` (branch `hotfix/2.3.1`) so the hotfix shipped without the in-flight v2.4 work that's already on `main`.
- This PR brings the same FileTree refreshRoot fix forward and bumps `package.json` / `tauri.conf.json` / `Cargo.{toml,lock}` / web `Hero.astro` / web `Download.astro` to `2.3.1`.
- Web VERSION bump means Cloudflare Pages will surface the v2.3.1 download links the next time it redeploys (no manual edit needed).

The FileTree bug was a Vue 3 ref identity-check edge case: `refreshRoot()` mutated a raw `Node` object after assigning it into `root.value`, then re-assigned the same reference back — Vue's setter saw the same identity and skipped the trigger. Fix routes the post-load updates through `root.value.x = y` instead.

## Test plan

- [x] Type-check (`pnpm vue-tsc --noEmit`) clean on `main` after merge — already verified locally before pushing this branch
- [x] Hotfix tag CI on `v2.3.1` — all 3 jobs (ubuntu-22.04, ubuntu-22.04-arm, windows-latest) green
- [x] Local Mac universal dmg signed + notarized + stapled, manual smoke test confirmed FileTree renders files (no Loading) on the freshly-installed v2.3.1 .app

🤖 Generated with [Claude Code](https://claude.com/claude-code)