### PR TITLE
ci(v2.4): pre-build solomd-mcp sidecar; web-clipper waits for publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,20 @@ jobs:
       - name: Install frontend dependencies
         run: cd app && pnpm install --frozen-lockfile
 
+      # Tauri's build.rs verifies externalBin presence at COMPILE time
+      # (not at bundle time), so the sidecar must exist before tauri-action
+      # runs cargo build. beforeBundleCommand can't help here — it runs
+      # after the rust build. Pre-build the sidecar for this matrix's
+      # rust triple, matching what tauri-action's TAURI_ENV_TARGET_TRIPLE
+      # will be.
+      - name: Pre-build solomd-mcp sidecar
+        shell: bash
+        run: |
+          set -euo pipefail
+          TRIPLE="$(rustc -vV | sed -n 's/^host: //p')"
+          echo "host triple: $TRIPLE"
+          bash scripts/build-mcp-sidecar.sh "$TRIPLE"
+
       - name: Build & release with tauri-action
         uses: tauri-apps/tauri-action@v0
         env:
@@ -241,6 +255,10 @@ jobs:
   # draft release.
   # ---------------------------------------------------------------------------
   web-clipper:
+    # Wait for the draft release to exist (one of the publish jobs creates it
+    # via tauri-action's `release: true`). Without `needs:`, we race against
+    # the matrix and fail with `release not found` when we land first.
+    needs: publish
     permissions:
       contents: write
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

The v2.4.0 tag's release workflow failed on all 3 publish jobs + web-clipper. Two CI bugs:

1. **Sidecar timing** — Tauri's build.rs verifies `externalBin` presence at compile time, not at bundle time. `beforeBundleCommand` runs *after* cargo build. So all 3 publish jobs failed at compile with `resource path 'binaries/solomd-mcp-<triple>' doesn't exist`. Fix: explicit "Pre-build solomd-mcp sidecar" step before `tauri-action`, run via `bash scripts/build-mcp-sidecar.sh \$(rustc -vV | sed -n 's/^host: //p')` on every matrix runner.

2. **Job ordering** — `web-clipper` job ran in parallel with the publish matrix and tried `gh release upload v2.4.0` before the draft existed (tauri-action creates it via `release: true`). Fix: `needs: publish`.

Local Mac builds via `scripts/build-mac.sh` were unaffected — that script builds both arch sidecars + lipos them into a universal binary up front.

## Test plan

- [ ] After merge: re-run the v2.4.0 release workflow (will rebuild Win/Linux artifacts on the latest workflow file). Mac dmg already built locally and ready to upload separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)