### PR TITLE
chore: v2.4.1 — bump version (CI fix took the v2.4.0 slot)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solomd",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
  "async-stream",
  "calamine",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solomd"
-version = "2.4.0"
+version = "2.4.1"
 description = "SoloMD — a lightweight, cross-platform Markdown + plain text editor"
 authors = ["zhitong"]
 edition = "2021"

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SoloMD",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "identifier": "app.solomd",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/app/src/components/AboutDialog.vue
+++ b/app/src/components/AboutDialog.vue
@@ -11,7 +11,7 @@ onMounted(async () => {
   try {
     VERSION.value = await getVersion();
   } catch {
-    VERSION.value = '2.4.0';
+    VERSION.value = '2.4.1';
   }
 });
 

--- a/web/src/components/Download.astro
+++ b/web/src/components/Download.astro
@@ -4,7 +4,7 @@ interface Props { lang: Lang }
 const { lang } = Astro.props;
 const tr = getT(lang);
 
-const VERSION = '2.4.0';
+const VERSION = '2.4.1';
 const REPO = 'zhitongblog/solomd';
 const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
 

--- a/web/src/components/Hero.astro
+++ b/web/src/components/Hero.astro
@@ -4,7 +4,7 @@ interface Props { lang: Lang }
 const { lang } = Astro.props;
 const tr = getT(lang);
 
-const VERSION = '2.4.0';
+const VERSION = '2.4.1';
 const REPO = 'zhitongblog/solomd';
 const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
 const whatsNewHref = lang === 'zh' ? '/zh/whats-new/' : '/whats-new/';


### PR DESCRIPTION
## Summary

v2.4.0 tag's CI failed; PR #33 merged the fix to main but it was simpler to bump to v2.4.1 than force-move the v2.4.0 tag (per cadence rules — append-only).

App source identical to v2.4.0; only the version-string fields change.

## Test plan
- [x] vue-tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)