### PR TITLE
v2.4.2 — macOS UX hotfix (issue #31)

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "solomd",
   "private": true,
-  "version": "2.4.1",
+  "version": "2.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "2.4.1"
+version = "2.4.2"
 dependencies = [
  "async-stream",
  "calamine",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solomd"
-version = "2.4.1"
+version = "2.4.2"
 description = "SoloMD — a lightweight, cross-platform Markdown + plain text editor"
 authors = ["zhitong"]
 edition = "2021"

--- a/app/src-tauri/src/runner.rs
+++ b/app/src-tauri/src/runner.rs
@@ -37,7 +37,9 @@ mod dev_bridge;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
-use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+use tauri::menu::{
+    AboutMetadata, MenuBuilder, MenuItemBuilder, PredefinedMenuItem, SubmenuBuilder,
+};
 use tauri::{Emitter, Manager, RunEvent};
 
 /// Tell macOS AppKit to use the given language for native dialogs
@@ -281,6 +283,56 @@ fn build_app_menu<R: tauri::Runtime>(
         .item(&about)
         .build()?;
 
+    // macOS: the first submenu becomes the "App menu" (titled with the
+    // app's process name) and is where users go for About / Settings /
+    // Quit by HIG convention. Without this, ⌘Q does nothing and the
+    // last menu item visually becomes "Close Tab" (issue #31).
+    #[cfg(target_os = "macos")]
+    {
+        let app_about_meta = AboutMetadata {
+            name: Some("SoloMD".into()),
+            version: Some(env!("CARGO_PKG_VERSION").into()),
+            credits: Some("Made by 智通 / xiangdong li".into()),
+            authors: Some(vec!["xiangdong li".into()]),
+            comments: Some("Lightweight, cross-platform Markdown editor.".into()),
+            website: Some("https://solomd.app".into()),
+            website_label: Some("solomd.app".into()),
+            ..Default::default()
+        };
+        let app_submenu = SubmenuBuilder::new(app, "SoloMD")
+            .about(Some(app_about_meta))
+            .separator()
+            .item(&settings_item)
+            .separator()
+            .item(&PredefinedMenuItem::services(app, None)?)
+            .separator()
+            .item(&PredefinedMenuItem::hide(app, None)?)
+            .item(&PredefinedMenuItem::hide_others(app, None)?)
+            .item(&PredefinedMenuItem::show_all(app, None)?)
+            .separator()
+            .item(&PredefinedMenuItem::quit(app, None)?)
+            .build()?;
+
+        let window_submenu = SubmenuBuilder::new(app, if lang == "zh" { "窗口" } else { "Window" })
+            .item(&PredefinedMenuItem::minimize(app, None)?)
+            .item(&PredefinedMenuItem::maximize(app, None)?)
+            .separator()
+            .item(&PredefinedMenuItem::close_window(app, None)?)
+            .build()?;
+
+        return MenuBuilder::new(app)
+            .items(&[
+                &app_submenu,
+                &file_submenu,
+                &edit_submenu,
+                &view_submenu,
+                &window_submenu,
+                &help_submenu,
+            ])
+            .build();
+    }
+
+    #[cfg(not(target_os = "macos"))]
     MenuBuilder::new(app)
         .items(&[&file_submenu, &edit_submenu, &view_submenu, &help_submenu])
         .build()

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "SoloMD",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "identifier": "app.solomd",
   "build": {
     "beforeDevCommand": "pnpm dev",
@@ -14,8 +14,8 @@
     "windows": [
       {
         "title": "SoloMD",
-        "width": 1000,
-        "height": 700,
+        "width": 1200,
+        "height": 800,
         "minWidth": 480,
         "minHeight": 360
       }

--- a/app/src/components/AboutDialog.vue
+++ b/app/src/components/AboutDialog.vue
@@ -11,7 +11,7 @@ onMounted(async () => {
   try {
     VERSION.value = await getVersion();
   } catch {
-    VERSION.value = '2.4.1';
+    VERSION.value = '2.4.2';
   }
 });
 

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -324,8 +324,8 @@ onBeforeUnmount(() => {
         @click="onCleanAI"
         v-bind:title="t('toolbar.cleanAiTitle')"
       >
+        <span class="clean-ai-broom">🧹</span>
         <span class="clean-ai-label">AI</span>
-        <span class="clean-ai-x">✕</span>
       </button>
       <button
         class="icon-btn ai-rewrite-btn"
@@ -569,10 +569,10 @@ onBeforeUnmount(() => {
 .clean-ai-label {
   letter-spacing: 0.04em;
 }
-.clean-ai-x {
-  font-size: 9px;
-  opacity: 0.6;
-  margin-left: 1px;
+.clean-ai-broom {
+  font-size: 11px;
+  opacity: 0.85;
+  margin-right: 1px;
 }
 .ai-rewrite-btn {
   position: relative;
@@ -632,6 +632,15 @@ onBeforeUnmount(() => {
 .copy-split__arrow:hover {
   color: var(--accent);
   background: var(--bg-hover);
+}
+/* The menu lives inside `.copy-split > .dropdown`, but if `.dropdown`
+ * is `position: relative` here the menu anchors to the 22 px chevron
+ * arrow and looks misaligned (issue #31). Demote that one `.dropdown`
+ * to static so the menu falls back to the wrapping `.copy-split`
+ * (which is relative), letting `right: 0` line up with the right edge
+ * of the whole Copy + chevron widget. */
+.copy-split > .dropdown {
+  position: static;
 }
 .copy-dropdown {
   right: 0;

--- a/app/src/composables/useShortcuts.ts
+++ b/app/src/composables/useShortcuts.ts
@@ -83,6 +83,11 @@ export function useShortcuts(hooks: Hooks = {}) {
     } else if (k === 'w') {
       e.preventDefault();
       if (tabs.activeId) files.closeTabSafe(tabs.activeId);
+    } else if (k === 't' && !e.shiftKey && !e.altKey) {
+      // v2.4.2: ⌘T mirrors Chrome / Obsidian "new tab" muscle memory.
+      // Same effect as ⌘N — both create a fresh markdown tab.
+      e.preventDefault();
+      files.newFile();
     } else if (k === 'p' && e.shiftKey) {
       e.preventDefault();
       settings.cycleViewMode();

--- a/web/src/components/Download.astro
+++ b/web/src/components/Download.astro
@@ -4,7 +4,7 @@ interface Props { lang: Lang }
 const { lang } = Astro.props;
 const tr = getT(lang);
 
-const VERSION = '2.4.1';
+const VERSION = '2.4.2';
 const REPO = 'zhitongblog/solomd';
 const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
 

--- a/web/src/components/Hero.astro
+++ b/web/src/components/Hero.astro
@@ -4,7 +4,7 @@ interface Props { lang: Lang }
 const { lang } = Astro.props;
 const tr = getT(lang);
 
-const VERSION = '2.4.1';
+const VERSION = '2.4.2';
 const REPO = 'zhitongblog/solomd';
 const baseUrl = `https://github.com/${REPO}/releases/download/v${VERSION}`;
 const whatsNewHref = lang === 'zh' ? '/zh/whats-new/' : '/whats-new/';


### PR DESCRIPTION
Fixes [#31](https://github.com/zhitongblog/solomd/issues/31). Six sub-bugs reported by @JokerQyou after first-launch on macOS — full breakdown in commit message.

Test plan:
- [x] cargo check
- [x] vue-tsc --noEmit
- [ ] Mac dmg local build + smoke test (after merge)