### PR TITLE
fix: PDF export timeout, outline toggle in tabs, mermaid overlay cont…

### DIFF
--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -76,7 +76,7 @@ pomodoro.rehydrate();
 // Pinia internals. Dev-only convenience — release builds ignore the
 // extra hook.
 (window as any).usePomodoroStore = usePomodoroStore;
-const { t } = useI18n();
+useI18n();
 
 const cursorLine = ref(1);
 const cursorCol = ref(1);
@@ -654,17 +654,6 @@ watchEffect(() => { void settings.aiEnabled; void settings.aiProvider; refreshAi
           <HistoryPanel v-if="showHistoryPane" />
         </aside>
         <div class="content">
-          <button
-            v-if="tabs.activeTab?.language === 'markdown' && !showOutlinePane"
-            class="outline-toggle"
-            @click="tabs.activeId && tabs.toggleOutline(tabs.activeId)"
-            :title="t('toolbar.outlineTooltip')"
-          >
-            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-              <line x1="8" y1="6" x2="21" y2="6" /><line x1="8" y1="12" x2="21" y2="12" /><line x1="8" y1="18" x2="21" y2="18" />
-              <line x1="3" y1="6" x2="3.01" y2="6" /><line x1="3" y1="12" x2="3.01" y2="12" /><line x1="3" y1="18" x2="3.01" y2="18" />
-            </svg>
-          </button>
           <BasesView v-if="basesOpen" />
           <TileRoot v-else :node="tiles.root" @cursor="onCursor" />
         </div>
@@ -780,26 +769,5 @@ watchEffect(() => { void settings.aiEnabled; void settings.aiProvider; refreshAi
   min-width: 0;
   overflow: hidden;
   position: relative;
-}
-.outline-toggle {
-  position: absolute;
-  top: calc(var(--tabbar-h, 34px) + 6px);
-  left: 6px;
-  z-index: 10;
-  padding: 4px 6px;
-  border-radius: 4px;
-  color: var(--text-faint);
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  opacity: 0;
-  transition: opacity 0.15s;
-  cursor: pointer;
-}
-.outline-toggle:hover {
-  opacity: 1 !important;
-  color: var(--text-muted);
-}
-.content:hover > .outline-toggle {
-  opacity: 0.5;
 }
 </style>

--- a/app/src/components/PaneTabBar.vue
+++ b/app/src/components/PaneTabBar.vue
@@ -128,6 +128,13 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick));
         :title="t.filePath || t.fileName"
       >
         <span class="tab__name">{{ t.fileName }}</span>
+        <button
+          v-if="t.language === 'markdown'"
+          class="tab__outline"
+          :class="{ 'tab__outline--active': t.showOutline }"
+          :title="t.showOutline ? 'Hide outline' : 'Show outline'"
+          @click.stop="tabs.toggleOutline(t.id)"
+        >≡</button>
         <span class="tab__dot" v-if="tabs.isDirty(t.id)">●</span>
         <button
           class="tab__close"
@@ -219,6 +226,29 @@ onBeforeUnmount(() => document.removeEventListener('click', onDocClick));
 .tab__dot {
   color: var(--accent);
   font-size: 10px;
+}
+.tab__outline {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-faint);
+  padding: 1px 4px;
+  line-height: 1;
+  border-radius: 3px;
+  opacity: 0;
+  transition: opacity 0.12s, color 0.12s, background 0.12s;
+}
+.tab:hover .tab__outline,
+.tab--active .tab__outline {
+  opacity: 1;
+}
+.tab__outline--active {
+  opacity: 1 !important;
+  color: var(--accent);
+  background: var(--bg-active);
+}
+.tab__outline:hover {
+  color: var(--accent);
+  background: var(--bg-hover);
 }
 .tab__close {
   padding: 0 4px;

--- a/app/src/components/Slideshow.vue
+++ b/app/src/components/Slideshow.vue
@@ -313,13 +313,15 @@ onBeforeUnmount(() => {
       <div class="slide__help-card">
         <h2>Slideshow Shortcuts</h2>
         <table>
-          <tr><td>Next slide</td><td>→ ↓ Space PageDown</td></tr>
-          <tr><td>Previous slide</td><td>← ↑ PageUp</td></tr>
-          <tr><td>First / last slide</td><td>Home / End</td></tr>
-          <tr><td>Toggle fullscreen</td><td>F</td></tr>
-          <tr><td>Show / hide this help</td><td>?</td></tr>
-          <tr><td>Exit</td><td>Esc</td></tr>
-          <tr><td>Vertical sub-slides</td><td>Use <code>--</code> separator</td></tr>
+          <tbody>
+            <tr><td>Next slide</td><td>→ ↓ Space PageDown</td></tr>
+            <tr><td>Previous slide</td><td>← ↑ PageUp</td></tr>
+            <tr><td>First / last slide</td><td>Home / End</td></tr>
+            <tr><td>Toggle fullscreen</td><td>F</td></tr>
+            <tr><td>Show / hide this help</td><td>?</td></tr>
+            <tr><td>Exit</td><td>Esc</td></tr>
+            <tr><td>Vertical sub-slides</td><td>Use <code>--</code> separator</td></tr>
+          </tbody>
         </table>
         <p class="slide__help-foot">
           Slides split by <code>---</code> (horizontal) or <code>--</code>

--- a/app/src/components/TabBar.vue
+++ b/app/src/components/TabBar.vue
@@ -105,7 +105,13 @@ watch(
         :title="tab.filePath || tab.fileName"
       >
         <span class="tab__name">{{ tab.fileName }}</span>
-        <span class="tab__outline" v-if="tab.showOutline && tab.language === 'markdown'" title="Outline on">≡</span>
+        <button
+          v-if="tab.language === 'markdown'"
+          class="tab__outline"
+          :class="{ 'tab__outline--active': tab.showOutline }"
+          :title="tab.showOutline ? 'Hide outline' : 'Show outline'"
+          @click.stop="tabs.toggleOutline(tab.id)"
+        >≡</button>
         <span class="tab__dot" v-if="isDirty(tab.id)">●</span>
         <button
           class="tab__close"
@@ -192,8 +198,27 @@ watch(
   font-size: 10px;
 }
 .tab__outline {
-  font-size: 11px;
+  font-size: 14px;
+  font-weight: 700;
   color: var(--text-faint);
+  padding: 1px 4px;
+  line-height: 1;
+  border-radius: 3px;
+  opacity: 0;
+  transition: opacity 0.12s, color 0.12s, background 0.12s;
+}
+.tab:hover .tab__outline,
+.tab--active .tab__outline {
+  opacity: 1;
+}
+.tab__outline--active {
+  opacity: 1 !important;
+  color: var(--accent);
+  background: var(--bg-active);
+}
+.tab__outline:hover {
+  color: var(--accent);
+  background: var(--bg-hover);
 }
 .tab__close {
   padding: 0 4px;

--- a/app/src/composables/useExport.ts
+++ b/app/src/composables/useExport.ts
@@ -263,11 +263,6 @@ export function useExport() {
     if (!path) return;
     const tid = toasts.info('Generating PDF…', 0);
     try {
-      // v2.5 F3: feed Settings → PDF defaults (with per-doc front-matter
-      // override) into the html2pdf.js builder. When the user hasn't
-      // touched Settings *and* there's no `pdf:` block, `userTouched`
-      // is false and the resolver returns null sentinels — `markdownToPdfBlob`
-      // then falls back to its pre-v2.5 hardcoded A4/10mm path.
       const pdfOpts = resolvePdfOptions(
         settings.pdfDefaults,
         ctx.content,

--- a/app/src/lib/image-overlay.ts
+++ b/app/src/lib/image-overlay.ts
@@ -128,6 +128,18 @@ const CSS = `
   -webkit-user-select: none;
   -webkit-user-drag: none;
 }
+.io-viewport--svg svg {
+  background: #fff;
+  border-radius: 6px;
+  padding: 16px;
+  box-sizing: content-box;
+}
+.io-viewport--svg-dark svg {
+  background: #1e1e2e;
+  border-radius: 6px;
+  padding: 16px;
+  box-sizing: content-box;
+}
 .io-footer {
   position: absolute;
   bottom: 16px;
@@ -362,8 +374,14 @@ export function openImageOverlay(opts: OverlayOptions) {
 
   // Clone source
   const clone = source.cloneNode(true) as HTMLElement;
+  const isSvg = source instanceof SVGElement;
   if (clone instanceof HTMLImageElement) {
     clone.draggable = false;
+  }
+  if (isSvg) {
+    const isDark = document.documentElement.getAttribute('data-theme') === 'dark'
+      || document.documentElement.classList.contains('dark');
+    viewport.classList.add(isDark ? 'io-viewport--svg-dark' : 'io-viewport--svg');
   }
   viewport.appendChild(clone);
   contentEl.appendChild(viewport);

--- a/app/src/lib/pdf-export.ts
+++ b/app/src/lib/pdf-export.ts
@@ -18,6 +18,8 @@ import { renderMarkdown, extractImageRoot } from './markdown';
 import type { ResolvedPdfOptions } from './pdf-options';
 import { rewriteImageUrls } from './image-resolve';
 
+const EXPORT_TIMEOUT_MS = 30_000;
+
 const PDF_CSS = `
   body { margin: 0; }
   .pdf-page {
@@ -236,65 +238,79 @@ export async function markdownToPdfBlob(
   root.appendChild(page);
   document.body.appendChild(root);
 
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    root.remove();
+  };
+
   try {
-    // Render any Mermaid blocks before capture.
-    await processMermaidBlocks(page);
-    // Give the browser a tick to lay everything out (KaTeX fonts especially).
-    await new Promise((r) => setTimeout(r, 60));
+    // Timeout guard — prevents the export from hanging the UI indefinitely
+    // if html2pdf.js or Mermaid gets stuck.
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('PDF export timed out')), EXPORT_TIMEOUT_MS),
+    );
 
-    // v2.5 F3: derive jsPDF / margin args from the resolved opts. When
-    // the caller didn't customize anything, fall back to the legacy
-    // hardcoded values so old users see exactly the same output as v2.4.
-    let margins: [number, number, number, number] = [10, 10, 12, 10];
-    let jsPdfFormat: string | [number, number] = 'a4';
-    let orientation: 'portrait' | 'landscape' = 'portrait';
-    if (pdfOpts && pdfOpts.pageSizeMm && pdfOpts.marginMm) {
-      margins = [
-        pdfOpts.marginMm.top,
-        pdfOpts.marginMm.right,
-        pdfOpts.marginMm.bottom,
-        pdfOpts.marginMm.left,
-      ];
-      // jsPDF accepts named formats ('a4' / 'letter' / 'legal') or [w, h].
-      const named = pageSizeLabelToJsPdf(pdfOpts.pageSizeLabel);
-      if (named) {
-        jsPdfFormat = named;
-        // 'a5' is portrait by default; same orientation logic as the
-        // others. We always emit portrait — landscape isn't a v2.5 feature.
-      } else {
-        jsPdfFormat = [pdfOpts.pageSizeMm.width, pdfOpts.pageSizeMm.height];
+    const work = async () => {
+      // Render any Mermaid blocks before capture.
+      await processMermaidBlocks(page);
+      // Give the browser a tick to lay everything out (KaTeX fonts especially).
+      await new Promise((r) => setTimeout(r, 60));
+
+      // v2.5 F3: derive jsPDF / margin args from the resolved opts. When
+      // the caller didn't customize anything, fall back to the legacy
+      // hardcoded values so old users see exactly the same output as v2.4.
+      let margins: [number, number, number, number] = [10, 10, 12, 10];
+      let jsPdfFormat: string | [number, number] = 'a4';
+      let orientation: 'portrait' | 'landscape' = 'portrait';
+      if (pdfOpts && pdfOpts.pageSizeMm && pdfOpts.marginMm) {
+        margins = [
+          pdfOpts.marginMm.top,
+          pdfOpts.marginMm.right,
+          pdfOpts.marginMm.bottom,
+          pdfOpts.marginMm.left,
+        ];
+        const named = pageSizeLabelToJsPdf(pdfOpts.pageSizeLabel);
+        if (named) {
+          jsPdfFormat = named;
+        } else {
+          jsPdfFormat = [pdfOpts.pageSizeMm.width, pdfOpts.pageSizeMm.height];
+        }
+        orientation =
+          pdfOpts.pageSizeMm.width > pdfOpts.pageSizeMm.height ? 'landscape' : 'portrait';
       }
-      orientation =
-        pdfOpts.pageSizeMm.width > pdfOpts.pageSizeMm.height ? 'landscape' : 'portrait';
-    }
 
-    const opts: any = {
-      margin: margins,
-      filename: `${title || 'document'}.pdf`,
-      image: { type: 'jpeg', quality: 0.96 },
-      html2canvas: {
-        scale: 2,
-        useCORS: true,
-        backgroundColor: '#ffffff',
-        letterRendering: true,
-        logging: false,
-      },
-      jsPDF: {
-        unit: 'mm',
-        format: jsPdfFormat,
-        orientation,
-      },
-      pagebreak: {
-        mode: ['css', 'legacy'],
-        avoid: ['pre', '.mermaid-block', 'table', 'blockquote', 'h1', 'h2', 'h3'],
-      },
+      const opts: any = {
+        margin: margins,
+        filename: `${title || 'document'}.pdf`,
+        image: { type: 'jpeg', quality: 0.96 },
+        html2canvas: {
+          scale: 2,
+          useCORS: true,
+          backgroundColor: '#ffffff',
+          letterRendering: true,
+          logging: false,
+        },
+        jsPDF: {
+          unit: 'mm',
+          format: jsPdfFormat,
+          orientation,
+        },
+        pagebreak: {
+          mode: ['css', 'legacy'],
+          avoid: ['pre', '.mermaid-block', 'table', 'blockquote', 'h1', 'h2', 'h3'],
+        },
+      };
+      const worker = html2pdf().set(opts).from(page);
+
+      const blob: Blob = await worker.outputPdf('blob');
+      return blob;
     };
-    const worker = html2pdf().set(opts).from(page);
 
-    const blob: Blob = await worker.outputPdf('blob');
-    return blob;
+    return await Promise.race([work(), timeout]);
   } finally {
-    document.body.removeChild(root);
+    cleanup();
   }
 }
 


### PR DESCRIPTION
  Summary

  - PDF 导出防卡死：为 markdownToPdfBlob 添加 30 秒超时保护（Promise.race），防止 html2pdf.js 或 Mermaid 渲染挂起时 UI 无限冻结；改进 DOM 清理逻辑，避免 double-remove 异常
  - Outline 切换移至 Tab 标签：移除编辑区左上角的浮动 outline 按钮，改为在每个 Markdown tab 的 ≌ 按钮上直接点击切换；活跃时高亮强调色，未活跃时 hover 可见（TabBar + PaneTabBar
  均已适配）
  - Mermaid 浮窗对比度修复：图片 overlay 中 SVG 图表根据当前主题自动添加背景卡片（浅色模式白底 #fff，深色模式 #1e1e2e），解决深色背景下 Mermaid 线条不可见的问题
  - HTML 规范修复：MarkdownHelp、Slideshow 中的 <table> 内补充 <tbody> 包裹，消除 Vite 警告