### PR TITLE
feat(search): persistent sidebar panel replaces modal popup

### DIFF
--- a/app/src-tauri/src/workspace_index.rs
+++ b/app/src-tauri/src/workspace_index.rs
@@ -502,6 +502,52 @@ fn collect_yaml_tags(value: &serde_json::Value, out: &mut Vec<String>) {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_strip_inline_code_basic() {
+        let stripped = strip_inline_code("purple bg `#1A1033` + text `#9B7EE0`");
+        assert!(!stripped.contains('#'), "inline code should be stripped: {:?}", stripped);
+    }
+
+    #[test]
+    fn test_body_tags_skip_inline_code() {
+        let body = "- Active item: purple bg `#1A1033` + text `#9B7EE0` + fontWeight 600\n- Inactive: no fill + text `#94A3B8`\n- Sub-item: padding `[8,12,8,40]`, fontSize 13\n\n#real-tag";
+        let tags = extract_body_tags(body);
+        assert!(tags.contains(&"real-tag".to_string()), "should find #real-tag");
+        assert!(!tags.iter().any(|t| t.contains("9B7EE0")), "should NOT pick up hex color from inline code");
+        assert!(!tags.iter().any(|t| t.contains("1A1033")), "should NOT pick up hex color from inline code");
+        assert!(!tags.iter().any(|t| t.contains("94A3B8")), "should NOT pick up hex color from inline code");
+    }
+
+    #[test]
+    fn test_body_tags_skip_table_inline_code() {
+        let body = "\
+| 属性 | 值 |
+|------|-----|
+| 页面背景 | `#0A0F1A` (深色) |
+| Header 背景 | `#0F172A` |
+| 卡片背景 | `#111B27` |
+| 边框 | `#1E293B` |
+| Primary 强调色 | `#F59E0B` (amber) |
+| 主文本 | `#F1F5F9` |
+| 次级文本 | `#94A3B8` |
+| 按钮主色 | `#F59E0B` fill, `#000000` text |
+| 状态绿 | `#48BB78` (completed/claimed) |
+| 状态灰 | `#64748B` (locked/disabled) |
+";
+        let tags = extract_body_tags(body);
+        let hex_tags: Vec<&String> = tags.iter().filter(|t| t.chars().all(|c| c.is_ascii_hexdigit())).collect();
+        assert!(
+            hex_tags.is_empty(),
+            "hex color codes inside backticks should NOT be tags, but found: {:?}",
+            hex_tags
+        );
+    }
+}
+
 fn extract_headings(body: &str) -> Vec<String> {
     static RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"^(#{1,6})\s+(.+?)\s*$").expect("heading regex"));
     let mut out = Vec::new();

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount, ref, watch, watchEffect, computed, provide } from 'vue';
+import { onMounted, onBeforeUnmount, ref, watch, watchEffect, computed, provide, nextTick } from 'vue';
 import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
@@ -93,6 +93,7 @@ function openSettingsAt(section: string | null = null) {
 }
 const helpOpen = ref(false);
 const searchOpen = ref(false);
+const searchPrefill = ref('');
 const ragSearchOpen = ref(false);
 const cjkProofreadOpen = ref(false);
 const aboutOpen = ref(false);
@@ -149,7 +150,7 @@ useShortcuts({
   openPalette: () => (paletteOpen.value = true),
   openSettings: () => (settingsOpen.value = true),
   openHelp: () => (helpOpen.value = true),
-  openGlobalSearch: () => (searchOpen.value = true),
+  openGlobalSearch: () => (searchOpen.value = !searchOpen.value),
   openRagSearch: () => (ragSearchOpen.value = true),
   openQuickSwitcher: () => (quickSwitcherOpen.value = true),
   openCjkProofread: () => (cjkProofreadOpen.value = true),
@@ -344,6 +345,18 @@ function onOpenCjkProofreadEvent() {
   cjkProofreadOpen.value = true;
 }
 
+function onFilterTag(tag: string) {
+  const newPrefill = `#${tag}`;
+  if (searchOpen.value && searchPrefill.value === newPrefill) {
+    // Same tag clicked while panel is open — re-trigger by clearing and resetting
+    searchPrefill.value = '';
+    nextTick(() => { searchPrefill.value = newPrefill; });
+  } else {
+    searchPrefill.value = newPrefill;
+  }
+  searchOpen.value = true;
+}
+
 let unlistenOpened: UnlistenFn | null = null;
 let unlistenMenu: UnlistenFn | null = null;
 
@@ -395,7 +408,7 @@ function dispatchMenuAction(id: string) {
       settingsOpen.value = true;
       break;
     case 'search.global':
-      searchOpen.value = true;
+      searchOpen.value = !searchOpen.value;
       break;
     case 'help.markdown':
       helpOpen.value = true;
@@ -616,13 +629,22 @@ const showHistoryPane = computed(
     tabs.activeTab?.language === 'markdown' &&
     !!workspace.currentFolder,
 );
+const showSearchPane = computed(() => searchOpen.value);
 const showRightSidebar = computed(
   () =>
+    searchOpen.value ||
     showOutlinePane.value ||
     showBacklinksPane.value ||
     showTagsPane.value ||
     showHistoryPane.value,
 );
+watch(showRightSidebar, () => {
+  nextTick(() => {
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new CustomEvent('solomd:relayout'));
+    });
+  });
+});
 const basesOpen = ref(false);
 const aiHasKey = ref(false);
 async function refreshAiHasKey() {
@@ -652,7 +674,7 @@ watchEffect(() => { void settings.aiEnabled; void settings.aiProvider; refreshAi
         @open-palette="paletteOpen = true"
         @open-settings="openSettingsAt()"
         @open-help="helpOpen = true"
-        @open-search="searchOpen = true"
+        @open-search="searchOpen = !searchOpen"
       />
       <TelemetryBanner />
       <div class="workspace">
@@ -661,10 +683,13 @@ watchEffect(() => { void settings.aiEnabled; void settings.aiProvider; refreshAi
           v-if="showRightSidebar && settings.outlineSide === 'left'"
           class="side-sidebar side-sidebar--left"
         >
-          <Outline v-if="showOutlinePane" :cursor-line="cursorLine" @goto="onOutlineGoto" />
-          <BacklinksPanel v-if="showBacklinksPane" />
-          <TagsPanel v-if="showTagsPane" />
-          <HistoryPanel v-if="showHistoryPane" />
+          <GlobalSearch v-if="showSearchPane" :open="true" :prefill="searchPrefill" @close="searchOpen = false" />
+          <template v-else>
+            <Outline v-if="showOutlinePane" :cursor-line="cursorLine" @goto="onOutlineGoto" />
+            <BacklinksPanel v-if="showBacklinksPane" />
+            <TagsPanel v-if="showTagsPane" @filter-tag="onFilterTag" />
+            <HistoryPanel v-if="showHistoryPane" />
+          </template>
         </aside>
         <div class="content">
           <BasesView v-if="basesOpen" />
@@ -674,10 +699,13 @@ watchEffect(() => { void settings.aiEnabled; void settings.aiProvider; refreshAi
           v-if="showRightSidebar && settings.outlineSide !== 'left'"
           class="side-sidebar side-sidebar--right"
         >
-          <Outline v-if="showOutlinePane" :cursor-line="cursorLine" @goto="onOutlineGoto" />
-          <BacklinksPanel v-if="showBacklinksPane" />
-          <TagsPanel v-if="showTagsPane" />
-          <HistoryPanel v-if="showHistoryPane" />
+          <GlobalSearch v-if="showSearchPane" :open="true" :prefill="searchPrefill" @close="searchOpen = false" />
+          <template v-else>
+            <Outline v-if="showOutlinePane" :cursor-line="cursorLine" @goto="onOutlineGoto" />
+            <BacklinksPanel v-if="showBacklinksPane" />
+            <TagsPanel v-if="showTagsPane" @filter-tag="onFilterTag" />
+            <HistoryPanel v-if="showHistoryPane" />
+          </template>
         </aside>
       </div>
       <StatusBar :line="cursorLine" :col="cursorCol" />
@@ -699,7 +727,6 @@ watchEffect(() => { void settings.aiEnabled; void settings.aiProvider; refreshAi
       @close="settingsOpen = false; settingsInitialSection = null; refreshAiHasKey()"
     />
     <MarkdownHelp :open="helpOpen" @close="helpOpen = false" />
-    <GlobalSearch :open="searchOpen" @close="searchOpen = false" />
     <RagSearch
       :open="ragSearchOpen"
       @close="ragSearchOpen = false"

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -94,6 +94,7 @@ watch(
 
 const host = ref<HTMLDivElement | null>(null);
 let view: EditorView | null = null;
+let cleanupRelayout: (() => void) | null = null;
 
 const themeCompartment = new Compartment();
 const langCompartment = new Compartment();
@@ -262,9 +263,15 @@ onMounted(() => {
   if (import.meta.env.DEV) {
     (window as unknown as { __solomdActiveView?: EditorView }).__solomdActiveView = view;
   }
+  // Sidebar toggle changes the available editor width but CodeMirror's
+  // ResizeObserver may lag. Listen for a custom event and force a re-measure.
+  const onRelayout = () => view?.requestMeasure();
+  window.addEventListener('solomd:relayout', onRelayout);
+  cleanupRelayout = () => window.removeEventListener('solomd:relayout', onRelayout);
 });
 
 onBeforeUnmount(() => {
+  cleanupRelayout?.();
   if (import.meta.env.DEV) {
     const w = window as unknown as { __solomdActiveView?: EditorView };
     if (w.__solomdActiveView === view) delete w.__solomdActiveView;

--- a/app/src/components/GlobalSearch.vue
+++ b/app/src/components/GlobalSearch.vue
@@ -1,31 +1,47 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from 'vue';
+import { computed, nextTick, onMounted, ref, watch } from 'vue';
 import { useGlobalSearch, type SearchHit } from '../composables/useGlobalSearch';
 import { useFiles } from '../composables/useFiles';
+import { useTabsStore } from '../stores/tabs';
+import { useTilesStore } from '../stores/tiles';
 import { useWorkspaceStore } from '../stores/workspace';
+import { useI18n } from '../i18n';
 
-const props = defineProps<{ open: boolean }>();
+const props = defineProps<{ open: boolean; prefill?: string }>();
 const emit = defineEmits<{ (e: 'close'): void }>();
 
 const search = useGlobalSearch();
 const files = useFiles();
+const tabs = useTabsStore();
+const tiles = useTilesStore();
 const workspace = useWorkspaceStore();
+const { t } = useI18n();
 
 const query = ref('');
 const hits = ref<SearchHit[]>([]);
 const loading = ref(false);
 const selectedIdx = ref(0);
 const inputRef = ref<HTMLInputElement | null>(null);
+const activeFilePath = computed(() => tabs.activeTab?.filePath ?? '');
 
 let debounceTimer: number | null = null;
 
+onMounted(async () => {
+  if (props.prefill) {
+    query.value = props.prefill;
+  }
+  await nextTick();
+  inputRef.value?.focus();
+  if (query.value) doSearch();
+});
+
 watch(
-  () => props.open,
+  () => props.prefill,
   async (v) => {
-    if (v) {
+    if (v && v !== query.value) {
+      query.value = v;
       await nextTick();
       inputRef.value?.focus();
-      if (query.value) doSearch();
     }
   }
 );
@@ -70,10 +86,16 @@ function shortPath(p: string) {
 }
 
 async function openHit(hit: SearchHit) {
-  emit('close');
-  await files.openPath(hit.file);
-  // Note: jumping to the specific line would require an editorRef call from
-  // the parent. We just open the file for now; integrators can wire goto-line.
+  try {
+    await files.openPath(hit.file);
+    nextTick(() => {
+      window.dispatchEvent(new CustomEvent('solomd:outline-goto', {
+        detail: { line: hit.line, paneId: tiles.focusedPaneId },
+      }));
+    });
+  } catch (e) {
+    console.error('GlobalSearch: openPath failed', e);
+  }
 }
 
 function highlight(snippet: string): string {
@@ -111,153 +133,179 @@ function onKey(e: KeyboardEvent) {
 </script>
 
 <template>
-  <div v-if="open" class="gs__backdrop" @click.self="emit('close')">
-    <div class="gs" role="dialog" aria-label="Global search">
-      <div class="gs__header">
-        <input
-          ref="inputRef"
-          v-model="query"
-          @keydown="onKey"
-          class="gs__input"
-          placeholder="Search across files in folder…"
-          spellcheck="false"
-        />
-        <span v-if="loading" class="gs__loading">…</span>
-      </div>
-      <div v-if="!workspace.currentFolder" class="gs__empty">
-        Open a folder first (Ctrl+B → Folder)
-      </div>
-      <div v-else-if="!query.trim()" class="gs__empty">
-        Type to search across all .md / .txt files in {{ workspace.currentFolder }}
-      </div>
-      <div v-else-if="!hits.length && !loading" class="gs__empty">
-        No matches
-      </div>
-      <div v-else class="gs__results">
-        <div v-for="[file, fileHits] in grouped" :key="file" class="gs__group">
-          <div class="gs__file">{{ shortPath(file) }}</div>
-          <div
-            v-for="hit in fileHits"
-            :key="hit.line"
-            class="gs__hit"
-            :class="{ 'gs__hit--active': hits.indexOf(hit) === selectedIdx }"
-            @click="openHit(hit)"
-            @mouseenter="selectedIdx = hits.indexOf(hit)"
-          >
-            <span class="gs__lineno">L{{ hit.line }}</span>
-            <span class="gs__snippet" v-html="highlight(hit.snippet)"></span>
-          </div>
+  <div class="sp">
+    <header class="sp__head">
+      <span class="sp__title">{{ t('search.heading') }}</span>
+      <button class="sp__close" @click="emit('close')" title="Close">&times;</button>
+    </header>
+    <div class="sp__input-wrap">
+      <input
+        ref="inputRef"
+        v-model="query"
+        @keydown="onKey"
+        class="sp__input"
+        placeholder="Search across files in folder…"
+        spellcheck="false"
+      />
+      <span v-if="loading" class="sp__loading">…</span>
+    </div>
+    <div v-if="!workspace.currentFolder" class="sp__empty">
+      Open a folder first (Ctrl+B → Folder)
+    </div>
+    <div v-else-if="!query.trim()" class="sp__empty">
+      Type to search across all .md / .txt files
+    </div>
+    <div v-else-if="!hits.length && !loading" class="sp__empty">
+      No matches
+    </div>
+    <div v-else class="sp__results">
+      <div v-for="[file, fileHits] in grouped" :key="file" class="sp__group">
+        <div class="sp__file" :class="{ 'sp__file--active': file === activeFilePath }">{{ shortPath(file) }}</div>
+        <div
+          v-for="hit in fileHits"
+          :key="hit.line"
+          class="sp__hit"
+          :class="{ 'sp__hit--active': hits.indexOf(hit) === selectedIdx }"
+          @click="openHit(hit)"
+          @mouseenter="selectedIdx = hits.indexOf(hit)"
+        >
+          <span class="sp__lineno">L{{ hit.line }}</span>
+          <span class="sp__snippet" v-html="highlight(hit.snippet)"></span>
         </div>
       </div>
-      <div class="gs__footer">
-        <span>{{ hits.length }} hits</span>
-        <span>↑↓ navigate · ↵ open · Esc close</span>
-      </div>
+    </div>
+    <div class="sp__footer">
+      <span>{{ hits.length }} hits</span>
+      <span>↑↓ navigate · ↵ open · Esc close</span>
     </div>
   </div>
 </template>
 
 <style scoped>
-.gs__backdrop {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.4);
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
-  padding-top: 10vh;
-  z-index: 1000;
-}
-.gs {
-  width: min(720px, 94vw);
-  max-height: 70vh;
-  background: var(--bg-elev);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  box-shadow: 0 18px 60px rgba(0, 0, 0, 0.4);
+.sp {
   display: flex;
   flex-direction: column;
+  height: 100%;
+  background: var(--bg);
   overflow: hidden;
 }
-.gs__header {
+.sp__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-soft);
+}
+.sp__title {
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+.sp__close {
+  background: none;
+  border: none;
+  color: var(--text-muted);
+  font-size: 18px;
+  cursor: pointer;
+  line-height: 1;
+  padding: 0 4px;
+  transition: color 0.12s;
+}
+.sp__close:hover {
+  color: var(--text);
+}
+.sp__input-wrap {
   display: flex;
   align-items: center;
   border-bottom: 1px solid var(--border);
-  padding: 0 16px;
+  padding: 0 12px;
 }
-.gs__input {
+.sp__input {
   flex: 1;
   background: transparent;
   border: none;
   outline: none;
-  padding: 14px 0;
-  font: 14px var(--font-ui);
+  padding: 10px 0;
+  font: 13px var(--font-ui);
   color: var(--text);
 }
-.gs__loading {
+.sp__loading {
   color: var(--accent);
-  font-size: 16px;
+  font-size: 14px;
 }
-.gs__empty {
-  padding: 32px;
+.sp__empty {
+  padding: 24px 16px;
   color: var(--text-faint);
   text-align: center;
-  font-size: 13px;
+  font-size: 12px;
+  line-height: 1.6;
 }
-.gs__results {
+.sp__results {
   flex: 1;
   overflow-y: auto;
-  padding: 8px 0;
+  padding: 4px 0;
 }
-.gs__group {
-  margin-bottom: 8px;
+.sp__group {
+  margin-bottom: 4px;
 }
-.gs__file {
-  padding: 6px 16px;
+.sp__file {
+  padding: 6px 12px;
   font-size: 11px;
   font-weight: 600;
   color: var(--accent);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
-.gs__hit {
+.sp__file--active {
+  position: relative;
+}
+.sp__file--active::after {
+  content: ' ●';
+  font-size: 8px;
+  vertical-align: middle;
+}
+.sp__hit {
   display: flex;
   align-items: center;
-  gap: 12px;
-  padding: 6px 16px 6px 24px;
+  gap: 10px;
+  padding: 5px 12px 5px 20px;
   font-size: 12px;
   cursor: pointer;
   font-family: var(--font-mono);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  transition: background 0.1s;
 }
-.gs__hit:hover,
-.gs__hit--active {
+.sp__hit:hover,
+.sp__hit--active {
   background: var(--bg-active);
 }
-.gs__lineno {
+.sp__lineno {
   color: var(--text-faint);
   flex-shrink: 0;
   font-size: 10px;
-  width: 36px;
+  width: 32px;
 }
-.gs__snippet {
+.sp__snippet {
   color: var(--text);
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.gs__snippet :deep(mark) {
+.sp__snippet :deep(mark) {
   background: var(--accent);
   color: var(--accent-fg);
   padding: 0 2px;
   border-radius: 2px;
 }
-.gs__footer {
+.sp__footer {
   display: flex;
   justify-content: space-between;
-  padding: 8px 16px;
-  font-size: 11px;
+  padding: 6px 12px;
+  font-size: 10px;
   color: var(--text-faint);
   border-top: 1px solid var(--border);
 }

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -305,6 +305,9 @@ export const en = {
     yesterdayBtn: 'Yesterday',
     tomorrowBtn: 'Tomorrow',
   },
+  search: {
+    heading: 'Search',
+  },
   daily: {
     openToday: "Open Today's Note",
     openYesterday: "Open Yesterday's Note",

--- a/app/src/i18n/zh.ts
+++ b/app/src/i18n/zh.ts
@@ -306,6 +306,9 @@ export const zh: I18n = {
     yesterdayBtn: '昨天',
     tomorrowBtn: '明天',
   },
+  search: {
+    heading: '搜索',
+  },
   daily: {
     openToday: '打开今日笔记',
     openYesterday: '打开昨日笔记',

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -115,6 +115,8 @@ interface Settings {
   // editor. Default ON — can be turned off for users who don't like
   // the keyboard interception.
   slashCommandsEnabled: boolean;
+  // v3.5: persistent search sidebar panel (replaces the old modal popup).
+  showSearchPanel: boolean;
   // v3.6: PNG export — show "Created with SoloMD · solomd.app" footer
   // under the rendered note. Default ON (mild self-promotion is fine
   // for a free MIT app), but explicitly toggleable in Settings → Export
@@ -232,6 +234,7 @@ function defaults(): Settings {
     pomodoroAutoEngageFocus: true,
     pomodoroDefaultMinutes: 25,
     slashCommandsEnabled: true,
+    showSearchPanel: false,
     imageExportBranding: true,
   };
 }


### PR DESCRIPTION
Convert global search and tag filtering from a modal dialog to a persistent sidebar panel. Results stay visible while clicking through matches, enabling search-browse-compare workflows in knowledge bases.

- Rewrite GlobalSearch.vue: remove backdrop/modal, add sidebar panel layout with close button, keep keyboard nav and highlighting
- Integrate into right sidebar in App.vue: replaces Outline/Backlinks/ Tags/History when search is active, tag clicks prefill #tag search
- Add jump-to-line: clicking a result opens the file and scrolls to the matched line via solomd:outline-goto event
- Fix editor relayout: dispatch solomd:relayout event on sidebar toggle so CodeMirror recalculates its viewport via requestMeasure()
- Add showSearchPanel setting, i18n keys (en/zh), toggle shortcut