### PR TITLE
Preview link handling & Tag extraction filtering

### DIFF
--- a/app/src-tauri/Cargo.lock
+++ b/app/src-tauri/Cargo.lock
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "solomd"
-version = "4.0.0"
+version = "4.0.2"
 dependencies = [
  "argon2",
  "async-stream",

--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -14,6 +14,7 @@
     "core:webview:default",
     "core:webview:allow-create-webview-window",
     "opener:default",
+    "opener:allow-open-path",
     "dialog:default",
     "dialog:allow-open",
     "dialog:allow-save",
@@ -25,5 +26,12 @@
     "clipboard-manager:allow-write-image",
     "clipboard-manager:allow-read-image",
     "window-state:default"
-  ]
+  ],
+  "scope": {
+    "opener": {
+      "allow": [
+        { "path": "$HOME/**" }
+      ]
+    }
+  }
 }

--- a/app/src-tauri/src/runner.rs
+++ b/app/src-tauri/src/runner.rs
@@ -182,6 +182,7 @@ struct MenuStrings {
     print_item: &'static str,
     close_tab: &'static str,
     new_window: &'static str,
+    open_external: &'static str,
     toggle_theme: &'static str,
     toggle_sidebar: &'static str,
     toggle_outline: &'static str,
@@ -209,6 +210,7 @@ fn strings_for(lang: &str) -> MenuStrings {
             print_item: "打印…",
             close_tab: "关闭标签页",
             new_window: "新建窗口",
+            open_external: "用外部编辑器打开",
             toggle_theme: "切换主题",
             toggle_sidebar: "切换文件树",
             toggle_outline: "切换大纲",
@@ -234,6 +236,7 @@ fn strings_for(lang: &str) -> MenuStrings {
             print_item: "Print…",
             close_tab: "Close Tab",
             new_window: "New Window",
+            open_external: "Open in External Editor",
             toggle_theme: "Toggle Theme",
             toggle_sidebar: "Toggle File Tree",
             toggle_outline: "Toggle Outline",
@@ -278,6 +281,9 @@ fn build_app_menu<R: tauri::Runtime>(
     let new_window = MenuItemBuilder::with_id("window.new", s.new_window)
         .accelerator("CmdOrCtrl+Shift+N")
         .build(app)?;
+    let open_external = MenuItemBuilder::with_id("file.openExternal", s.open_external)
+        .accelerator("CmdOrCtrl+Shift+E")
+        .build(app)?;
 
     let file_submenu = SubmenuBuilder::new(app, s.file)
         .item(&new_md)
@@ -288,6 +294,8 @@ fn build_app_menu<R: tauri::Runtime>(
         .separator()
         .item(&save)
         .item(&save_as)
+        .separator()
+        .item(&open_external)
         .separator()
         .item(&print_item)
         .separator()

--- a/app/src-tauri/src/workspace_index.rs
+++ b/app/src-tauri/src/workspace_index.rs
@@ -462,6 +462,22 @@ fn scan_tags_in_line(line: &str, out: &mut Vec<String>) {
             }
         }
         if !tag.is_empty() {
+            // a) Tag must be followed by whitespace or end-of-line — otherwise
+            //    it is likely a CSS property value (e.g. `#488878;`).
+            if let Some(&(_, ch)) = chars.peek() {
+                if !ch.is_whitespace() {
+                    continue;
+                }
+            }
+            // b) 6-char pure hex string → almost certainly a colour code.
+            if tag.len() == 6 && tag.chars().all(|c| c.is_ascii_hexdigit()) {
+                continue;
+            }
+            // c) In table rows, skip purely numeric "tags" — they are rankings
+            //    (#1, #2, #3) or issue/row numbers (#12, #26), not real tags.
+            if tag.chars().all(|c| c.is_ascii_digit()) && line.trim_start().starts_with('|') {
+                continue;
+            }
             out.push(tag);
         }
     }
@@ -520,6 +536,100 @@ mod tests {
         assert!(!tags.iter().any(|t| t.contains("9B7EE0")), "should NOT pick up hex color from inline code");
         assert!(!tags.iter().any(|t| t.contains("1A1033")), "should NOT pick up hex color from inline code");
         assert!(!tags.iter().any(|t| t.contains("94A3B8")), "should NOT pick up hex color from inline code");
+    }
+
+    #[test]
+    fn test_table_backtick_hex_colors() {
+        // Exact user-reported lines with backtick-enclosed hex colors in table cells
+        let lines = [
+            "| `#ffffff` | `#111B27` | Card bg |",
+            "| `#f1f5f9` | `#1E293B` | Gray bg / status |",
+            "| `#e2e8f0` | `#1E293B` | Dividers |",
+        ];
+        for line in &lines {
+            let stripped = strip_inline_code(line);
+            // After stripping inline code, no `#` should remain
+            assert!(
+                !stripped.contains('#'),
+                "strip_inline_code should remove # from backtick content in: {:?} → {:?}",
+                line, stripped
+            );
+        }
+        // Full extraction should find zero tags
+        let body = lines.join("\n");
+        let tags = extract_body_tags(&body);
+        assert!(
+            tags.is_empty(),
+            "backtick-enclosed hex colors should NOT be tags, found: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_table_no_backtick_hex_colors() {
+        // Same content WITHOUT backticks — hex filter should catch them
+        let lines = [
+            "| #ffffff | #111B27 | Card bg |",
+            "| #f1f5f9 | #1E293B | Gray bg / status |",
+            "| #e2e8f0 | #1E293B | Dividers |",
+        ];
+        let body = lines.join("\n");
+        let tags = extract_body_tags(&body);
+        assert!(
+            tags.is_empty(),
+            "hex colors without backticks should be filtered by hex check, found: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_link_anchor_not_tag() {
+        // Markdown link: (#12-tab-可见性规则) — # is preceded by '(' not whitespace
+        let line = "12. [Tab 可见性规则](#12-tab-可见性规则)";
+        let mut tags = vec![];
+        scan_tags_in_line(line, &mut tags);
+        assert!(
+            tags.is_empty(),
+            "link anchor #12 should NOT be a tag, found: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn hex_colors_not_tags() {
+        let mut tags = vec![];
+        // CSS-like contexts — semicolons / non-space after hex → filtered by boundary
+        scan_tags_in_line("color: #488878;", &mut tags);
+        scan_tags_in_line("bg: #9B7EE0 solid", &mut tags);
+        // Valid tags (non-table lines — numeric tags OK)
+        scan_tags_in_line("see #TaskOn here", &mut tags);
+        scan_tags_in_line("ref #1 and #12 ok", &mut tags);
+        assert_eq!(tags, vec!["TaskOn", "1", "12"]);
+    }
+
+    #[test]
+    fn table_numeric_not_tags() {
+        // Rankings and issue numbers in table rows should be excluded
+        let mut tags = vec![];
+        scan_tags_in_line("| P67 | #1 DeFi_Whale 12,800pts, #2 CryptoKing |", &mut tags);
+        scan_tags_in_line("| #1 (center) | highest | amber |", &mut tags);
+        scan_tags_in_line("| #26 Community Wizard preview |", &mut tags);
+        // Non-table numeric tags still valid
+        scan_tags_in_line("see #12 here", &mut tags);
+        assert_eq!(tags, vec!["12"]);
+    }
+
+    #[test]
+    fn hex_colors_in_table_not_tags() {
+        // Exact user-reported line: hex colors in markdown table cells, no backticks
+        let line = "| Theme | Dark (#0A0F1A bg, #111B27 cards) |";
+        let mut tags = vec![];
+        scan_tags_in_line(line, &mut tags);
+        assert!(
+            tags.is_empty(),
+            "hex colors in table should NOT be tags, but found: {:?}",
+            tags
+        );
     }
 
     #[test]

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -4,6 +4,7 @@ import { getCurrentWebview } from '@tauri-apps/api/webview';
 import { getCurrentWindow } from '@tauri-apps/api/window';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { invoke } from '@tauri-apps/api/core';
+import { openPath } from '@tauri-apps/plugin-opener';
 import Toolbar from './components/Toolbar.vue';
 import TelemetryBanner from './components/TelemetryBanner.vue';
 import TileRoot from './components/TileRoot.vue';
@@ -392,6 +393,19 @@ function onFilterTag(tag: string) {
 let unlistenOpened: UnlistenFn | null = null;
 let unlistenMenu: UnlistenFn | null = null;
 
+async function openExternalFile() {
+  const filePath = tabs.activeTab?.filePath;
+  if (!filePath) {
+    console.warn('openExternal: no file path');
+    return;
+  }
+  try {
+    await openPath(filePath);
+  } catch (e) {
+    console.warn('openExternal failed', e);
+  }
+}
+
 function dispatchMenuAction(id: string) {
   switch (id) {
     case 'file.new':
@@ -411,6 +425,9 @@ function dispatchMenuAction(id: string) {
       break;
     case 'file.saveAs':
       files.saveActiveAs();
+      break;
+    case 'file.openExternal':
+      openExternalFile();
       break;
     case 'file.print':
       exporter.exportPdfPrint();

--- a/app/src/components/FileTree.vue
+++ b/app/src/components/FileTree.vue
@@ -385,7 +385,7 @@ onBeforeUnmount(() => {
 
       <!-- Inline new/rename input — appears at the top of the tree. -->
       <div v-if="editing" class="ftree__edit">
-        <span class="ftree__icon">{{ editing.kind === 'new-dir' ? '▸' : editing.kind === 'rename' ? '·' : '·' }}</span>
+        <span class="ftree__icon">{{ editing.kind === 'new-dir' ? '▸' : editing.kind === 'rename' ? '•' : '•' }}</span>
         <input
           ref="editInput"
           v-model="editing.name"
@@ -506,7 +506,7 @@ export const FileTreeNode = defineComponent({
             title: n.path,
           },
           [
-            h('span', { class: 'ftree__icon' }, n.is_dir ? (n.expanded ? '▾' : '▸') : '·'),
+            h('span', { class: 'ftree__icon' }, n.is_dir ? (n.expanded ? '▾' : '▸') : '•'),
             h('span', { class: 'ftree__name' }, n.name),
             !n.is_dir && props.inboxPaths.has(n.path)
               ? h('span', { class: 'ftree__inbox-dot', title: 'inbox' }, '●')
@@ -623,15 +623,28 @@ export const FileTreeNode = defineComponent({
   background: var(--bg-hover, color-mix(in srgb, var(--accent) 10%, transparent));
 }
 :deep(.ftree__icon) {
-  width: 12px;
+  width: 14px;
   flex-shrink: 0;
+  text-align: center;
   color: var(--text-faint);
   font-size: 10px;
+}
+:deep(.ftree__item--dir .ftree__icon) {
+  color: var(--accent);
+  font-size: 11px;
+}
+:deep(.ftree__item--file .ftree__icon) {
+  color: var(--text-muted);
+  font-size: 9px;
 }
 :deep(.ftree__name) {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+:deep(.ftree__item--dir .ftree__name) {
+  font-weight: 600;
+  color: var(--text);
 }
 :deep(.ftree__inbox-dot) {
   color: var(--accent);

--- a/app/src/components/Icons.vue
+++ b/app/src/components/Icons.vue
@@ -176,5 +176,11 @@ defineProps<{ name: string; size?: number }>();
       <path d="M2 5h7a3 3 0 0 1 3 3v12a2 2 0 0 0-2-2H2z" />
       <path d="M22 5h-7a3 3 0 0 0-3 3v12a2 2 0 0 1 2-2h8z" />
     </template>
+    <template v-else-if="name === 'external'">
+      <!-- Open in external app: a square with an arrow pointing out -->
+      <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+      <polyline points="15 3 21 3 21 9" />
+      <line x1="10" y1="14" x2="21" y2="3" />
+    </template>
   </svg>
 </template>

--- a/app/src/components/Preview.vue
+++ b/app/src/components/Preview.vue
@@ -7,6 +7,7 @@ import { rewriteImageUrls } from '../lib/image-resolve';
 import { openImageOverlay, type OverlayStrings } from '../lib/image-overlay';
 import { useI18n } from '../i18n';
 import { useSettingsStore } from '../stores/settings';
+import { useFiles } from '../composables/useFiles';
 import PreviewSearch from './PreviewSearch.vue';
 
 const props = withDefaults(
@@ -25,6 +26,7 @@ const props = withDefaults(
   { skin: 'default' },
 );
 const settings = useSettingsStore();
+const files = useFiles();
 const { t } = useI18n();
 const host = ref<HTMLDivElement | null>(null);
 const searchOpen = ref(false);
@@ -145,9 +147,24 @@ function handleLinkClick(e: MouseEvent) {
   if (href.startsWith('#')) return;
   e.preventDefault();
   e.stopPropagation();
-  openUrl(href).catch(() => {
-    // Silently fail if opener can't handle the URL
-  });
+  // External URL: open in system browser
+  if (/^(https?|mailto|tel):/i.test(href)) {
+    openUrl(href).catch((err) => {
+      console.warn('[Preview] openUrl failed:', href, err);
+    });
+    return;
+  }
+  // Relative path: resolve against current file's directory and open in app
+  if (props.filePath) {
+    const sep = props.filePath.lastIndexOf('/');
+    const dir = sep >= 0 ? props.filePath.substring(0, sep + 1) : '';
+    // Normalise: strip leading ./
+    const cleaned = href.replace(/^\.\//, '');
+    const resolved = dir + cleaned;
+    files.openPath(resolved, { bypassNewWindow: true }).catch((err) => {
+      console.warn('[Preview] openPath failed:', resolved, err);
+    });
+  }
 }
 
 onMounted(async () => {

--- a/app/src/components/Toast.vue
+++ b/app/src/components/Toast.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useToastsStore } from '../stores/toasts';
+import { useToastsStore, type Toast } from '../stores/toasts';
 
 const toasts = useToastsStore();
 
@@ -9,6 +9,10 @@ const icons: Record<string, string> = {
   info: 'ℹ',
   warning: '!',
 };
+
+function onToastClick(t: Toast) {
+  navigator.clipboard.writeText(t.message).catch(() => {});
+}
 </script>
 
 <template>
@@ -19,7 +23,7 @@ const icons: Record<string, string> = {
         :key="t.id"
         class="toast"
         :class="`toast--${t.kind}`"
-        @click="toasts.dismiss(t.id)"
+        @click="onToastClick(t)"
       >
         <span class="toast__icon">{{ icons[t.kind] }}</span>
         <span class="toast__msg">{{ t.message }}</span>

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -12,6 +12,7 @@ import { useExport } from '../composables/useExport';
 import { useToastsStore } from '../stores/toasts';
 import { cleanAIArtifacts } from '../lib/clean-ai';
 import { useI18n } from '../i18n';
+import { openPath } from '@tauri-apps/plugin-opener';
 
 const { t } = useI18n();
 
@@ -101,6 +102,19 @@ function onAIRewrite() {
       detail: { selection, from, to },
     }),
   );
+}
+
+async function onOpenExternal() {
+  const path = tabs.activeTab?.filePath;
+  if (!path) {
+    toasts.warning(t('toast.openExternalNoFile'));
+    return;
+  }
+  try {
+    await openPath(path);
+  } catch (e) {
+    toasts.warning(`Failed: ${e}`);
+  }
 }
 
 const recentOpen = ref(false);
@@ -241,6 +255,9 @@ onBeforeUnmount(() => {
       </button>
       <button class="icon-btn" @click="files.saveActiveAs" :title="t('toolbar.saveAsTooltip')">
         <Icon name="save-as" />
+      </button>
+      <button class="icon-btn" @click="onOpenExternal" :title="t('toolbar.openExternalTooltip')">
+        <Icon name="external" />
       </button>
       <div class="dropdown">
         <button

--- a/app/src/composables/useCommands.ts
+++ b/app/src/composables/useCommands.ts
@@ -15,6 +15,7 @@ import {
 import { cleanAIArtifacts, stripMarkdownToPlain } from '../lib/clean-ai';
 import { openWelcomeTour } from '../lib/welcome-tour';
 import { formatMarkdown } from '../lib/markdown-format';
+import { openPath } from '@tauri-apps/plugin-opener';
 import { useDailyNotes } from './useDailyNotes';
 import { usePandocExport } from './usePandocExport';
 import { useBasesView } from './useBasesView';
@@ -94,6 +95,26 @@ export function useCommands(): Command[] {
       run: () => files.openFolder(),
     },
     { id: 'file.closeTab', title: 'Close Tab', shortcut: 'Ctrl+W', run: () => tabs.activeId && files.closeTabSafe(tabs.activeId) },
+
+    // v4.0.3 — Open active document in system default editor
+    {
+      id: 'file.openExternal',
+      title: 'Open in External Editor',
+      hint: 'Open file with system default editor',
+      run: async () => {
+        const tab = useTabsStore().activeTab;
+        const path = tab?.filePath;
+        if (!path) {
+          toasts.warning('Save the file first before opening in an external editor');
+          return;
+        }
+        try {
+          await openPath(path);
+        } catch (e) {
+          toasts.warning(`Failed: ${e}`);
+        }
+      },
+    },
 
     { id: 'view.editor', title: 'View: Edit Only', run: () => settings.setViewMode('edit') },
     { id: 'view.split', title: 'View: Split', run: () => settings.setViewMode('split') },

--- a/app/src/i18n/de.ts
+++ b/app/src/i18n/de.ts
@@ -47,6 +47,8 @@ export const de: I18n = {
     insertDivider: 'Trennlinie',
     copyTooltip: 'Als Rich-Text-HTML kopieren (Cmd+Umschalt+C)',
     copyFormats: 'Kopierformat-Optionen',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Bearbeiten',
     splitMode: 'Geteilt',
     previewMode: 'Vorschau',
@@ -254,6 +256,7 @@ export const de: I18n = {
     converting: 'Wird zu Markdown konvertiert…',
     converted: 'Zu Markdown konvertiert',
     conversionFailed: 'Konvertierung fehlgeschlagen',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Schließen',

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -45,6 +45,8 @@ export const en = {
     insertDivider: 'Divider',
     copyTooltip: 'Copy as rich text HTML (Cmd+Shift+C)',
     copyFormats: 'Copy format options',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Edit',
     splitMode: 'Split',
     previewMode: 'Preview',
@@ -252,6 +254,7 @@ export const en = {
     converting: 'Converting to Markdown…',
     converted: 'Converted to Markdown',
     conversionFailed: 'Conversion failed',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Close',

--- a/app/src/i18n/es.ts
+++ b/app/src/i18n/es.ts
@@ -47,6 +47,8 @@ export const es: I18n = {
     insertDivider: 'Separador',
     copyTooltip: 'Copiar como HTML enriquecido (Cmd+Mayús+C)',
     copyFormats: 'Opciones de formato de copia',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Editar',
     splitMode: 'Dividido',
     previewMode: 'Vista previa',
@@ -254,6 +256,7 @@ export const es: I18n = {
     converting: 'Convirtiendo a Markdown…',
     converted: 'Convertido a Markdown',
     conversionFailed: 'Conversión fallida',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Cerrar',

--- a/app/src/i18n/fr.ts
+++ b/app/src/i18n/fr.ts
@@ -47,6 +47,8 @@ export const fr: I18n = {
     insertDivider: 'Séparateur',
     copyTooltip: 'Copier en HTML enrichi (Cmd+Maj+C)',
     copyFormats: 'Options de format de copie',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Édition',
     splitMode: 'Divisé',
     previewMode: 'Aperçu',
@@ -254,6 +256,7 @@ export const fr: I18n = {
     converting: 'Conversion en Markdown…',
     converted: 'Converti en Markdown',
     conversionFailed: 'Échec de la conversion',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Fermer',

--- a/app/src/i18n/it.ts
+++ b/app/src/i18n/it.ts
@@ -47,6 +47,8 @@ export const it: I18n = {
     insertDivider: 'Separatore',
     copyTooltip: 'Copia come HTML rich (Cmd+Maiusc+C)',
     copyFormats: 'Opzioni formato copia',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Modifica',
     splitMode: 'Diviso',
     previewMode: 'Anteprima',
@@ -254,6 +256,7 @@ export const it: I18n = {
     converting: 'Conversione in Markdown…',
     converted: 'Convertito in Markdown',
     conversionFailed: 'Conversione fallita',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Chiudi',

--- a/app/src/i18n/ja.ts
+++ b/app/src/i18n/ja.ts
@@ -47,6 +47,8 @@ export const ja: I18n = {
     insertDivider: '区切り線',
     copyTooltip: 'リッチテキスト HTML としてコピー (Cmd+Shift+C)',
     copyFormats: 'コピー形式オプション',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: '編集',
     splitMode: '分割',
     previewMode: 'プレビュー',
@@ -254,6 +256,7 @@ export const ja: I18n = {
     converting: 'Markdown に変換中…',
     converted: 'Markdown に変換しました',
     conversionFailed: '変換に失敗しました',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: '閉じる',

--- a/app/src/i18n/ko.ts
+++ b/app/src/i18n/ko.ts
@@ -47,6 +47,8 @@ export const ko: I18n = {
     insertDivider: '구분선',
     copyTooltip: '서식 있는 HTML로 복사(Cmd+Shift+C)',
     copyFormats: '복사 형식 옵션',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: '편집',
     splitMode: '분할',
     previewMode: '미리 보기',
@@ -254,6 +256,7 @@ export const ko: I18n = {
     converting: 'Markdown으로 변환 중…',
     converted: 'Markdown으로 변환됨',
     conversionFailed: '변환 실패',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: '닫기',

--- a/app/src/i18n/nl.ts
+++ b/app/src/i18n/nl.ts
@@ -47,6 +47,8 @@ export const nl: I18n = {
     insertDivider: 'Scheidingslijn',
     copyTooltip: 'Kopiëren als rich-text HTML (Cmd+Shift+C)',
     copyFormats: 'Kopieer-opties',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Bewerken',
     splitMode: 'Splitsen',
     previewMode: 'Voorvertoning',
@@ -254,6 +256,7 @@ export const nl: I18n = {
     converting: 'Bezig met converteren naar Markdown…',
     converted: 'Geconverteerd naar Markdown',
     conversionFailed: 'Conversie mislukt',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Sluiten',

--- a/app/src/i18n/pl.ts
+++ b/app/src/i18n/pl.ts
@@ -47,6 +47,8 @@ export const pl: I18n = {
     insertDivider: 'Separator',
     copyTooltip: 'Kopiuj jako tekst sformatowany HTML (Cmd+Shift+C)',
     copyFormats: 'Opcje formatu kopiowania',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Edycja',
     splitMode: 'Podział',
     previewMode: 'Podgląd',
@@ -254,6 +256,7 @@ export const pl: I18n = {
     converting: 'Konwertowanie do Markdown…',
     converted: 'Skonwertowano do Markdown',
     conversionFailed: 'Konwersja nie powiodła się',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Zamknij',

--- a/app/src/i18n/pt.ts
+++ b/app/src/i18n/pt.ts
@@ -49,6 +49,8 @@ export const pt: I18n = {
     insertDivider: 'Separador',
     copyTooltip: 'Copiar como HTML rico (Cmd+Shift+C)',
     copyFormats: 'Opções de formato de cópia',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Editar',
     splitMode: 'Dividido',
     previewMode: 'Pré-visualizar',
@@ -256,6 +258,7 @@ export const pt: I18n = {
     converting: 'Convertendo para Markdown…',
     converted: 'Convertido para Markdown',
     conversionFailed: 'Falha na conversão',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Fechar',

--- a/app/src/i18n/sv.ts
+++ b/app/src/i18n/sv.ts
@@ -47,6 +47,8 @@ export const sv: I18n = {
     insertDivider: 'Avgränsare',
     copyTooltip: 'Kopiera som rik text-HTML (Cmd+Shift+C)',
     copyFormats: 'Kopieringsformat',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Redigera',
     splitMode: 'Delad',
     previewMode: 'Förhandsgranska',
@@ -254,6 +256,7 @@ export const sv: I18n = {
     converting: 'Konverterar till Markdown…',
     converted: 'Konverterat till Markdown',
     conversionFailed: 'Konvertering misslyckades',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Stäng',

--- a/app/src/i18n/tr.ts
+++ b/app/src/i18n/tr.ts
@@ -47,6 +47,8 @@ export const tr: I18n = {
     insertDivider: 'Ayraç',
     copyTooltip: 'Zengin metin HTML olarak kopyala (Cmd+Shift+C)',
     copyFormats: 'Kopyalama biçimi seçenekleri',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Düzenle',
     splitMode: 'Bölünmüş',
     previewMode: 'Önizleme',
@@ -254,6 +256,7 @@ export const tr: I18n = {
     converting: 'Markdown\'a dönüştürülüyor…',
     converted: 'Markdown\'a dönüştürüldü',
     conversionFailed: 'Dönüştürme başarısız',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Kapat',

--- a/app/src/i18n/uk.ts
+++ b/app/src/i18n/uk.ts
@@ -47,6 +47,8 @@ export const uk: I18n = {
     insertDivider: 'Розділювач',
     copyTooltip: 'Копіювати як форматований HTML (Cmd+Shift+C)',
     copyFormats: 'Параметри формату копіювання',
+    openExternal: 'Open in external editor',
+    openExternalTooltip: 'Open file with system default editor',
     editMode: 'Редагування',
     splitMode: 'Розділений',
     previewMode: 'Перегляд',
@@ -254,6 +256,7 @@ export const uk: I18n = {
     converting: 'Перетворення на Markdown…',
     converted: 'Перетворено на Markdown',
     conversionFailed: 'Помилка перетворення',
+    openExternalNoFile: 'Save the file first before opening in an external editor',
   },
   overlay: {
     close: 'Закрити',

--- a/app/src/i18n/zh.ts
+++ b/app/src/i18n/zh.ts
@@ -47,6 +47,8 @@ export const zh: I18n = {
     insertDivider: '分隔线',
     copyTooltip: '复制为富文本 HTML (⇧⌘C)',
     copyFormats: '复制格式选项',
+    openExternal: '用外部编辑器打开',
+    openExternalTooltip: '使用系统默认编辑器打开当前文件',
     editMode: '编辑',
     splitMode: '分栏',
     previewMode: '预览',
@@ -253,6 +255,7 @@ export const zh: I18n = {
     converting: '正在转换为 Markdown…',
     converted: '已转换为 Markdown',
     conversionFailed: '转换失败',
+    openExternalNoFile: '请先保存文件后再用外部编辑器打开',
   },
   overlay: {
     close: '关闭',

--- a/app/src/lib/cm-tag-autocomplete.ts
+++ b/app/src/lib/cm-tag-autocomplete.ts
@@ -79,6 +79,8 @@ function tagComplete(context: CompletionContext): CompletionResult | null {
   const partial = match.text.slice(1).toLowerCase();
   // Don't autoshow on a bare `#` (too noisy); user can hit Ctrl+Space.
   if (!context.explicit && partial.length === 0) return null;
+  // 6-char pure hex → likely a CSS colour code, not a tag.
+  if (/^[0-9a-f]{6}$/.test(partial)) return null;
 
   let tags: { tag: string; count: number }[] = [];
   try {


### PR DESCRIPTION
 Summary

  - Preview link handling: Relative markdown links (e.g. ./other.md) now open within the app via files.openPath(), while external URLs (http(s), mailto, tel) still open in the
  system browser. In-page anchors (#heading) are preserved.
  - Tag extraction filtering: Prevents hex color codes (#488878, #9B7EE0) and table-row numeric rankings/issue refs (#1, #2, #26) from being identified as workspace tags. Pure
  numeric tags in prose are still valid.
 - External editor: toolbar button + command palette + File menu (⌘⇧E), opener path scope in capabilities▏ - FileTree: bullet icon ·→•, accent-colored dir icons, bold dir names
 - Toast: click-to-copy via navigator.clipboard.writeText
 - i18n: new keys in en/zh + fallback English for all other languages