### PR TITLE
feat: three independent zoom axes via View menu

### DIFF
--- a/app/src-tauri/capabilities/default.json
+++ b/app/src-tauri/capabilities/default.json
@@ -13,6 +13,7 @@
     "core:window:allow-scale-factor",
     "core:webview:default",
     "core:webview:allow-create-webview-window",
+    "core:webview:allow-set-webview-zoom",
     "opener:default",
     "opener:allow-open-path",
     "dialog:default",

--- a/app/src-tauri/src/runner.rs
+++ b/app/src-tauri/src/runner.rs
@@ -187,6 +187,15 @@ struct MenuStrings {
     toggle_sidebar: &'static str,
     toggle_outline: &'static str,
     cycle_view: &'static str,
+    ui_zoom_in: &'static str,
+    ui_zoom_out: &'static str,
+    ui_zoom_reset: &'static str,
+    editor_zoom_in: &'static str,
+    editor_zoom_out: &'static str,
+    editor_zoom_reset: &'static str,
+    preview_zoom_in: &'static str,
+    preview_zoom_out: &'static str,
+    preview_zoom_reset: &'static str,
     palette: &'static str,
     global_search: &'static str,
     settings_menu: &'static str,
@@ -215,6 +224,15 @@ fn strings_for(lang: &str) -> MenuStrings {
             toggle_sidebar: "切换文件树",
             toggle_outline: "切换大纲",
             cycle_view: "切换视图模式 (编辑/分栏/预览)",
+            ui_zoom_in: "整体界面：放大",
+            ui_zoom_out: "整体界面：缩小",
+            ui_zoom_reset: "整体界面：复位",
+            editor_zoom_in: "编辑器：放大字号",
+            editor_zoom_out: "编辑器：缩小字号",
+            editor_zoom_reset: "编辑器：复位字号",
+            preview_zoom_in: "预览：放大字号",
+            preview_zoom_out: "预览：缩小字号",
+            preview_zoom_reset: "预览：复位字号",
             palette: "命令面板",
             global_search: "在文件夹中搜索…",
             settings_menu: "设置…",
@@ -241,6 +259,15 @@ fn strings_for(lang: &str) -> MenuStrings {
             toggle_sidebar: "Toggle File Tree",
             toggle_outline: "Toggle Outline",
             cycle_view: "Cycle Edit/Split/Preview",
+            ui_zoom_in: "UI: Zoom In",
+            ui_zoom_out: "UI: Zoom Out",
+            ui_zoom_reset: "UI: Reset Zoom",
+            editor_zoom_in: "Editor: Zoom In",
+            editor_zoom_out: "Editor: Zoom Out",
+            editor_zoom_reset: "Editor: Reset Zoom",
+            preview_zoom_in: "Preview: Zoom In",
+            preview_zoom_out: "Preview: Zoom Out",
+            preview_zoom_reset: "Preview: Reset Zoom",
             palette: "Command Palette",
             global_search: "Search in Folder…",
             settings_menu: "Settings…",
@@ -323,6 +350,33 @@ fn build_app_menu<R: tauri::Runtime>(
     let cycle_view = MenuItemBuilder::with_id("view.cycleView", s.cycle_view)
         .accelerator("CmdOrCtrl+Shift+P")
         .build(app)?;
+    let ui_zoom_in = MenuItemBuilder::with_id("view.zoomUiIn", s.ui_zoom_in)
+        .accelerator("CmdOrCtrl+=")
+        .build(app)?;
+    let ui_zoom_out = MenuItemBuilder::with_id("view.zoomUiOut", s.ui_zoom_out)
+        .accelerator("CmdOrCtrl+-")
+        .build(app)?;
+    let ui_zoom_reset = MenuItemBuilder::with_id("view.zoomUiReset", s.ui_zoom_reset)
+        .accelerator("CmdOrCtrl+0")
+        .build(app)?;
+    let editor_zoom_in = MenuItemBuilder::with_id("view.zoomEditorIn", s.editor_zoom_in)
+        .accelerator("CmdOrCtrl+Shift+=")
+        .build(app)?;
+    let editor_zoom_out = MenuItemBuilder::with_id("view.zoomEditorOut", s.editor_zoom_out)
+        .accelerator("CmdOrCtrl+Shift+-")
+        .build(app)?;
+    let editor_zoom_reset = MenuItemBuilder::with_id("view.zoomEditorReset", s.editor_zoom_reset)
+        .accelerator("CmdOrCtrl+Shift+0")
+        .build(app)?;
+    let preview_zoom_in = MenuItemBuilder::with_id("view.zoomPreviewIn", s.preview_zoom_in)
+        .accelerator("CmdOrCtrl+Control+=")
+        .build(app)?;
+    let preview_zoom_out = MenuItemBuilder::with_id("view.zoomPreviewOut", s.preview_zoom_out)
+        .accelerator("CmdOrCtrl+Control+-")
+        .build(app)?;
+    let preview_zoom_reset = MenuItemBuilder::with_id("view.zoomPreviewReset", s.preview_zoom_reset)
+        .accelerator("CmdOrCtrl+Control+0")
+        .build(app)?;
     let palette = MenuItemBuilder::with_id("view.cmdPalette", s.palette)
         .accelerator("CmdOrCtrl+Shift+K")
         .build(app)?;
@@ -339,6 +393,18 @@ fn build_app_menu<R: tauri::Runtime>(
         .item(&toggle_sidebar)
         .item(&toggle_outline)
         .item(&cycle_view)
+        .separator()
+        .item(&ui_zoom_in)
+        .item(&ui_zoom_out)
+        .item(&ui_zoom_reset)
+        .separator()
+        .item(&editor_zoom_in)
+        .item(&editor_zoom_out)
+        .item(&editor_zoom_reset)
+        .separator()
+        .item(&preview_zoom_in)
+        .item(&preview_zoom_out)
+        .item(&preview_zoom_reset)
         .separator()
         .item(&palette)
         .item(&global_search)

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -264,6 +264,12 @@ watchEffect(() => {
   document.documentElement.style.setProperty('--ui-font-size', `${settings.uiFontSize}px`);
 });
 
+// Preview/ReadingView font size — independent axis from the editor.
+// ⌘⇧=/⌘⇧- target the editor; ⌘⌥=/⌘⌥- target the preview.
+watchEffect(() => {
+  document.documentElement.style.setProperty('--content-font-size', `${settings.previewFontSize}px`);
+});
+
 // Sync native menu bar language
 watchEffect(() => {
   invoke('set_menu_language', { lang: settings.language }).catch(() => {});
@@ -407,6 +413,15 @@ async function openExternalFile() {
   }
 }
 
+async function applyUiZoom(level: number) {
+  settings.setUiZoom(level);
+  try {
+    await getCurrentWebview().setZoom(settings.uiZoom);
+  } catch (e) {
+    console.warn('setZoom failed', e);
+  }
+}
+
 function dispatchMenuAction(id: string) {
   switch (id) {
     case 'file.new':
@@ -450,6 +465,33 @@ function dispatchMenuAction(id: string) {
       break;
     case 'view.cycleView':
       settings.cycleViewMode();
+      break;
+    case 'view.zoomUiIn':
+      applyUiZoom(settings.uiZoom + 0.2);
+      break;
+    case 'view.zoomUiOut':
+      applyUiZoom(settings.uiZoom - 0.2);
+      break;
+    case 'view.zoomUiReset':
+      applyUiZoom(1.0);
+      break;
+    case 'view.zoomEditorIn':
+      settings.setFontSize(settings.fontSize + 1);
+      break;
+    case 'view.zoomEditorOut':
+      settings.setFontSize(settings.fontSize - 1);
+      break;
+    case 'view.zoomEditorReset':
+      settings.setFontSize(14);
+      break;
+    case 'view.zoomPreviewIn':
+      settings.setPreviewFontSize(settings.previewFontSize + 1);
+      break;
+    case 'view.zoomPreviewOut':
+      settings.setPreviewFontSize(settings.previewFontSize - 1);
+      break;
+    case 'view.zoomPreviewReset':
+      settings.setPreviewFontSize(15);
       break;
     case 'view.cmdPalette':
       paletteOpen.value = true;
@@ -603,6 +645,13 @@ onMounted(async () => {
     });
   } catch (err) {
     console.warn('menu listener not available', err);
+  }
+
+  // Restore persisted UI zoom on startup.
+  try {
+    await getCurrentWebview().setZoom(settings.uiZoom);
+  } catch (e) {
+    console.warn('initial setZoom failed', e);
   }
 
   // Drag-drop file open

--- a/app/src/components/Preview.vue
+++ b/app/src/components/Preview.vue
@@ -263,7 +263,7 @@ defineExpose({ scrollToLine, openSearch });
   padding: 28px 36px 64px;
   color: var(--text);
   font-family: var(--font-ui);
-  font-size: 15px;
+  font-size: var(--content-font-size, 15px);
   line-height: 1.7;
 }
 .preview-content--fit {

--- a/app/src/stores/settings.ts
+++ b/app/src/stores/settings.ts
@@ -25,6 +25,8 @@ interface Settings {
   theme: Theme;
   viewMode: ViewMode;
   fontSize: number;
+  previewFontSize: number;
+  uiZoom: number;
   fontFamily: string;
   wordWrap: boolean;
   showLineNumbers: boolean;
@@ -218,6 +220,8 @@ function defaults(): Settings {
     theme: prefersDark ? 'dark' : 'light',
     viewMode: 'edit',
     fontSize: 14,
+    previewFontSize: 15,
+    uiZoom: 1.0,
     fontFamily: 'JetBrains Mono',
     wordWrap: true,
     showLineNumbers: true,
@@ -430,6 +434,14 @@ export const useSettingsStore = defineStore('settings', {
     },
     setFontSize(n: number) {
       this.fontSize = Math.max(10, Math.min(28, n));
+      this.persist();
+    },
+    setPreviewFontSize(n: number) {
+      this.previewFontSize = Math.max(10, Math.min(32, n));
+      this.persist();
+    },
+    setUiZoom(n: number) {
+      this.uiZoom = Math.max(0.5, Math.min(3.0, n));
       this.persist();
     },
     setFontFamily(f: string) {


### PR DESCRIPTION
Adds 9 menu items under View, each backed by a native macOS keyboard accelerator that fires through AppKit (immune to the WKWebView zoom polyfill that previously made ⌘=/⌘⇧= behave inconsistently):

  ⌘=  / ⌘-  / ⌘0   — whole UI (Tauri setZoom, persisted across sessions)
  ⌘⇧= / ⌘⇧- / ⌘⇧0 — editor font only (settings.fontSize, existing setting)
  ⌃⌘= / ⌃⌘- / ⌃⌘0 — preview font only (settings.previewFontSize, new)

Changes:
- capabilities/default.json: grant `core:webview:allow-set-webview-zoom` so the frontend can programmatically drive the UI zoom level.
- runner.rs: build 9 new MenuItemBuilder entries with accelerators, plus en/zh localization strings, slotted into the View submenu in three separator-delimited groups (UI / Editor / Preview).
- settings.ts: new `previewFontSize` (10–32, default 15) and `uiZoom` (0.5–3.0, default 1.0) fields with setters; persisted via the existing localStorage machinery.
- App.vue: 9 new dispatchMenuAction cases; new `applyUiZoom` helper that calls `getCurrentWebview().setZoom`; watchEffect pushing `settings.previewFontSize` into a `--content-font-size` CSS variable; on-mount restore so the UI zoom level survives restart.
- Preview.vue: replace hardcoded `font-size: 15px` with `var(--content-font-size, 15px)` so the preview font tracks the setting (and ⌃⌘= shortcut).

The three axes are deliberately decoupled — pressing ⌃⌘= grows only the rendered markdown, leaving the editor pane and sidebar unchanged, which is useful when you want comfortable preview reading without losing editor density.