### PR TITLE
fix(win): Win11-ARM window title now updates on cold-start file open

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -11,7 +11,7 @@
          `user-scalable=no` because the app provides its own ⌘+/⌘-/⌘0
          zoom controls; pinch-zoom would break editor selection. -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, user-scalable=no" />
-    <title>Tauri + Vue + Typescript App</title>
+    <title>SoloMD</title>
   </head>
 
   <body>

--- a/app/src/App.vue
+++ b/app/src/App.vue
@@ -315,15 +315,34 @@ watch(
 // Window title — keep "<filename> — SoloMD" so the OS taskbar /
 // dock / Cmd-Tab can distinguish multiple SoloMD windows. Falls back
 // to "SoloMD" when no document is active. Issue #53.
+//
+// Win11-ARM regression (v4.5 report, but pre-existing since v4.4.x — the
+// cold-start-with-file path is byte-identical): the document loaded but
+// the title stayed "SoloMD". On Windows the JS `setTitle()` issued during
+// the cold-start mount burst didn't land (the window isn't ready to accept
+// it yet, and the rejected promise was swallowed), whereas macOS WKWebView
+// applied it fine. Two-pronged, platform-agnostic fix:
+//   1. Set `document.title` too — on Windows, WebView2 mirrors the native
+//      window title from the page title, so this lands even when the
+//      direct `setTitle()` call is dropped. (Also fixes the stale
+//      "Tauri + Vue …" placeholder that index.html shipped with.)
+//   2. Await `setTitle()` so a rejection is actually caught + logged,
+//      instead of floating off as an unhandled promise.
+const applyWindowTitle = async (name?: string) => {
+  const title = name ? `${name} — SoloMD` : 'SoloMD';
+  document.title = title;
+  try {
+    await getCurrentWindow().setTitle(title);
+  } catch (err) {
+    // Non-Tauri context (Vitest, SSR) — or a window not yet ready to
+    // accept it; document.title above is the cross-platform fallback.
+    console.debug('setTitle failed (document.title fallback applied)', err);
+  }
+};
 watch(
   () => tabs.activeTab?.fileName,
   (name) => {
-    const title = name ? `${name} — SoloMD` : 'SoloMD';
-    try {
-      void getCurrentWindow().setTitle(title);
-    } catch {
-      // Non-Tauri context (Vitest, SSR) — silently no-op.
-    }
+    void applyWindowTitle(name);
   },
   { immediate: true },
 );


### PR DESCRIPTION
## What

Win11-ARM cold-start with a file argument opened the document fine but the window title stayed `SoloMD` instead of `<filename> — SoloMD`. macOS (WKWebView) was unaffected.

## Root cause — NOT a v4.5 regression

Initially suspected the v4.5 `runner.rs` delta, but that only registers commands that are never reached during startup. The cold-start file-open + title path (`main.rs` argv → `PendingOpen` → `drain_pending_opens` → `openPath` → title watcher) is **byte-identical to v4.4.3**, so this was a pre-existing Windows bug since v4.4.x.

On Windows the WebView2 host mirrors the native window title from the page's `document.title`; the JS `getCurrentWindow().setTitle()` issued during the cold-start mount burst didn't land.

## Fix

- **`App.vue`** — set `document.title` alongside `setTitle()` (Windows picks it up via WebView2), and `await setTitle()` so a rejection is logged instead of floating off.
- **`index.html`** — replace stale `Tauri + Vue + Typescript App` `<title>` with `SoloMD` (correct WebView2 initial mirror, no placeholder flash).

The earlier WIP revert of `runner.rs` is undone here, keeping the #94 desktop rag-command registrations.

## Verification — real Win11-ARM hardware (UTM VM, real WebView2)

Driven headlessly via the guest agent (interactive scheduled task into the logged-in session, `EnumWindows` read in-session), comparing the main `Tauri Window`:

| Build | Main window title |
|-------|-------------------|
| Old v4.5.0 | `SoloMD` ❌ |
| CI build w/ fix | `regtest.md — SoloMD` ✅ |

Typecheck (`vue-tsc --noEmit`) passes. macOS unaffected (`document.title` is harmless there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)