### PR TITLE
fix(win): copy honors the editor selection (was copying the whole document)

### DIFF
--- a/app/src/composables/useExport.ts
+++ b/app/src/composables/useExport.ts
@@ -1,4 +1,5 @@
 import { save as saveDialog } from '@tauri-apps/plugin-dialog';
+import { EditorView } from '@codemirror/view';
 import { invoke } from '@tauri-apps/api/core';
 import { writeText, writeHtml, writeImage } from '@tauri-apps/plugin-clipboard-manager';
 import { Image } from '@tauri-apps/api/image';
@@ -206,8 +207,49 @@ function stripMarkdown(src: string): string {
  * `@mousedown.prevent` (focus preserved), or a plain `@click` button (focus
  * lost — but the selection range survives).
  */
+/**
+ * Read the active editor selection straight from CodeMirror's `EditorView`
+ * state — the source of truth. This is required for **rectangular / column
+ * selections** (#90): those are *multiple* selection ranges, which Chromium /
+ * WebView2's single-range `window.getSelection()` can't represent, so the old
+ * DOM-based reader saw a collapsed/empty selection and callers fell back to
+ * the *whole document* ("select a block, copy → got everything"). Reading the
+ * ranges from CM state also survives the editor losing DOM focus when a
+ * toolbar Copy button is clicked (CM keeps the selection in state).
+ *
+ * Ranges are joined with the document's own line break, matching CodeMirror's
+ * native multi-selection copy.
+ */
+function cmSelectionText(): string | null {
+  const editors = Array.from(document.querySelectorAll<HTMLElement>('.cm-editor'));
+  if (!editors.length) return null;
+  // Prefer the focused editor; fall back to any editor that holds a non-empty
+  // selection (covers blur-on-toolbar-click and split panes / tiles).
+  const focused = document.querySelector<HTMLElement>('.cm-editor.cm-focused');
+  const ordered = focused ? [focused, ...editors.filter((e) => e !== focused)] : editors;
+  for (const el of ordered) {
+    const view = EditorView.findFromDOM(el);
+    if (!view) continue;
+    const parts: string[] = [];
+    for (const r of view.state.selection.ranges) {
+      if (r.empty) continue;
+      parts.push(view.state.sliceDoc(r.from, r.to));
+    }
+    if (parts.length) {
+      const text = parts.join(view.state.lineBreak);
+      return text.trim() ? text : null;
+    }
+  }
+  return null;
+}
+
 function getEditorSelectionMd(): string | null {
   if (typeof document === 'undefined') return null;
+  // Primary: CodeMirror state (handles normal + rectangular selections).
+  const cmText = cmSelectionText();
+  if (cmText) return cmText;
+  // Fallback: DOM selection — for rendered text in the preview pane, which
+  // is not a CodeMirror editor.
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0 || sel.isCollapsed) return null;
   const range = sel.getRangeAt(0);


### PR DESCRIPTION
## What

On Windows, **"select a portion, copy → got the entire document."** The toolbar Copy menu and `Ctrl+Shift+C` (Copy as HTML / Markdown / Plain Text) copied the whole file instead of the selection.

## Root cause

`getEditorSelectionMd()` read the selection via `window.getSelection()`. On **WebView2 that returns an empty/collapsed selection for the CodeMirror editor** — even for a plain multi-line selection — so `copySource()` fell back to the whole document. macOS WKWebView *does* expose the DOM selection, which is why it only reproduced on Windows. Column/rectangular selections (#90) are *multiple* ranges and fail anywhere the single-range DOM Selection API is used.

## Fix

`app/src/composables/useExport.ts` — read the selection from CodeMirror's `EditorView` state (the source of truth): collect every non-empty range via `sliceDoc` and join with the doc's line break (matching CM's native multi-selection copy). The view is found via `EditorView.findFromDOM('.cm-editor')`, which also survives the editor losing DOM focus when a toolbar Copy button is clicked. The DOM-selection path is kept as a fallback for the rendered preview pane.

## Verification — real Win11-ARM (UTM VM, real WebView2)

Driven headlessly: open a 6-line doc, select 2 lines, `Ctrl+Shift+C`, read the clipboard.

| Selection (2 of 6 lines) | Old v4.5.0 | Fixed build |
|---|---|---|
| Clipboard | **108 chars = whole doc** ❌ | **36 chars = the 2 selected lines** ✅ |

Screenshot confirmed the 2-line highlight + status bar "已选: 2 词 / 32 字符". Typecheck (`vue-tsc --noEmit`) passes; macOS unaffected (DOM fallback unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)