### PR TITLE
feat: toolbar doc name display + Reveal in File Tree tab menu

### DIFF
--- a/app/src/components/PaneTabBar.vue
+++ b/app/src/components/PaneTabBar.vue
@@ -3,6 +3,8 @@ import { computed, nextTick, ref, watch } from 'vue';
 import { revealItemInDir } from '@tauri-apps/plugin-opener';
 import { useTabsStore } from '../stores/tabs';
 import { useTilesStore } from '../stores/tiles';
+import { useSettingsStore } from '../stores/settings';
+import { useWorkspaceStore } from '../stores/workspace';
 import { useFiles } from '../composables/useFiles';
 import { useI18n } from '../i18n';
 import type { SplitDirection } from '../types';
@@ -14,6 +16,8 @@ const props = defineProps<{
 
 const tabs = useTabsStore();
 const tiles = useTilesStore();
+const settings = useSettingsStore();
+const workspace = useWorkspaceStore();
 const files = useFiles();
 const { t } = useI18n();
 
@@ -81,7 +85,7 @@ async function closeMany(ids: string[]) {
   }
 }
 
-async function onTabAction(action: 'close' | 'closeLeft' | 'closeRight' | 'closeOthers' | 'closeSaved' | 'closeAll' | 'revealInFolder') {
+async function onTabAction(action: 'close' | 'closeLeft' | 'closeRight' | 'closeOthers' | 'closeSaved' | 'closeAll' | 'revealInFolder' | 'revealInFileTree') {
   const m = ctxMenu.value;
   closeCtxMenu();
   if (!m) return;
@@ -92,6 +96,16 @@ async function onTabAction(action: 'close' | 'closeLeft' | 'closeRight' | 'close
     const path = list[idx]?.filePath;
     if (!path) return;
     try { await revealItemInDir(path); } catch (e) { console.warn('reveal failed', e); }
+    return;
+  }
+  if (action === 'revealInFileTree') {
+    const path = list[idx]?.filePath;
+    if (!path) return;
+    const parent = path.replace(/[\\/][^\\/]+$/, '');
+    if (parent && parent !== path) {
+      if (!settings.showFileTree) settings.toggleFileTree();
+      workspace.setFolder(parent);
+    }
     return;
   }
   const ids = (() => {
@@ -333,6 +347,7 @@ onBeforeUnmount(() => {
         <button class="ctx-item" :disabled="!ctxFlags?.hasAny"   @click="onTabAction('closeAll')">{{ t('tabMenu.closeAll') }}</button>
         <div class="ctx-sep" />
         <button class="ctx-item" :disabled="!ctxFlags?.hasFilePath" @click="onTabAction('revealInFolder')">{{ t('tabMenu.revealInFolder') }}</button>
+        <button class="ctx-item" :disabled="!ctxFlags?.hasFilePath" @click="onTabAction('revealInFileTree')">{{ t('tabMenu.revealInFileTree') }}</button>
         <div class="ctx-sep" />
         <button class="ctx-item" @click="splitPane('horizontal')">Split Right</button>
         <button class="ctx-item" @click="splitPane('vertical')">Split Down</button>

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -578,7 +578,14 @@ onBeforeUnmount(() => {
     <div
       class="toolbar__spacer"
       :data-tauri-drag-region="macTitleBar ? '' : undefined"
-    ></div>
+    >
+      <span
+        v-if="tabs.activeTab?.fileName"
+        class="toolbar__doc-name"
+        :title="tabs.activeTab?.filePath || tabs.activeTab?.fileName"
+        :data-tauri-drag-region="macTitleBar ? '' : undefined"
+      >{{ tabs.activeTab.fileName }}</span>
+    </div>
 
     <div class="toolbar__group" v-if="isMarkdown">
       <button
@@ -908,7 +915,16 @@ onBeforeUnmount(() => {
   left: auto;
   min-width: 220px;
 }
-.toolbar__spacer { flex: 1 1 0; min-width: 0; }
+.toolbar__spacer { flex: 1 1 0; min-width: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.toolbar__doc-name {
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  cursor: default;
+}
 .toolbar__divider {
   width: 1px;
   height: 16px;

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -321,6 +321,13 @@ onBeforeUnmount(() => {
       <span class="brand__hash">#</span><span class="brand__md">MD</span>
     </div>
 
+    <span
+      v-if="tabs.activeTab?.fileName"
+      class="toolbar__title"
+      :title="tabs.activeTab?.filePath || tabs.activeTab?.fileName"
+      :data-tauri-drag-region="macTitleBar ? '' : undefined"
+    >{{ tabs.activeTab.fileName }}</span>
+
     <div class="toolbar__group">
       <div class="dropdown">
         <button
@@ -535,14 +542,7 @@ onBeforeUnmount(() => {
     <div
       class="toolbar__spacer"
       :data-tauri-drag-region="macTitleBar ? '' : undefined"
-    >
-      <span
-        v-if="tabs.activeTab?.fileName"
-        class="toolbar__doc-name"
-        :title="tabs.activeTab?.filePath || tabs.activeTab?.fileName"
-        :data-tauri-drag-region="macTitleBar ? '' : undefined"
-      >{{ tabs.activeTab.fileName }}</span>
-    </div>
+    ></div>
 
     <div class="toolbar__group" v-if="isMarkdown">
       <button
@@ -819,14 +819,23 @@ onBeforeUnmount(() => {
   display: inline-block;
 }
 
-.toolbar__spacer { flex: 1 1 0; min-width: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; }
-.toolbar__doc-name {
-  font-size: 12px;
-  color: var(--text-muted);
+.toolbar__spacer { flex: 1 1 0; min-width: 0; }
+/* Document title sits right after the #MD brand, mirroring a native window
+   title (VSCode / macOS Notes style). min-width:0 + flex-shrink:1 lets it
+   ellipsis-shrink on narrow windows instead of pushing tool groups off the
+   right edge (overrides `.toolbar > * { flex-shrink: 0 }`). */
+.toolbar__title {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  margin-left: 4px;
+  padding-right: 8px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  max-width: 100%;
+  max-width: 280px;
+  min-width: 0;
+  flex-shrink: 1;
   cursor: default;
 }
 .toolbar__divider {

--- a/app/src/components/Toolbar.vue
+++ b/app/src/components/Toolbar.vue
@@ -194,7 +194,6 @@ async function onOpenExternal() {
 const recentOpen = ref(false);
 const exportOpen = ref(false);
 const newOpen = ref(false);
-const copyOpen = ref(false);
 const insertOpen = ref(false);
 const pomoOpen = ref(false);
 
@@ -202,8 +201,6 @@ const newBtnRef = ref<HTMLElement | null>(null);
 const recentBtnRef = ref<HTMLElement | null>(null);
 const exportBtnRef = ref<HTMLElement | null>(null);
 const insertBtnRef = ref<HTMLElement | null>(null);
-const copyBtnRef = ref<HTMLElement | null>(null);
-
 const menuPos = ref<{ top: number; left?: number; right?: number } | null>(null);
 const floatStyle = computed<Record<string, string | number> | undefined>(() => {
   if (!menuPos.value) return undefined;
@@ -268,24 +265,21 @@ function closeAllDropdowns() {
   newOpen.value = false;
   recentOpen.value = false;
   exportOpen.value = false;
-  copyOpen.value = false;
   insertOpen.value = false;
   pomoOpen.value = false;
 }
 // Exclusive open: opening one dropdown closes others.
-function toggleDropdown(name: 'new' | 'recent' | 'export' | 'copy' | 'insert') {
+function toggleDropdown(name: 'new' | 'recent' | 'export' | 'insert') {
   const isOpen =
     (name === 'new' && newOpen.value) ||
     (name === 'recent' && recentOpen.value) ||
     (name === 'export' && exportOpen.value) ||
-    (name === 'copy' && copyOpen.value) ||
     (name === 'insert' && insertOpen.value);
   closeAllDropdowns();
   if (!isOpen) {
     if (name === 'new') { positionMenuFromButton(newBtnRef.value); newOpen.value = true; }
     else if (name === 'recent') { positionMenuFromButton(recentBtnRef.value); recentOpen.value = true; }
     else if (name === 'export') { positionMenuFromButton(exportBtnRef.value); exportOpen.value = true; }
-    else if (name === 'copy') { positionMenuFromButton(copyBtnRef.value, 'right'); copyOpen.value = true; }
     else if (name === 'insert') { positionMenuFromButton(insertBtnRef.value); insertOpen.value = true; }
   }
 }
@@ -437,6 +431,9 @@ onBeforeUnmount(() => {
             <button class="dropdown__item dropdown__item--single" @mousedown.prevent="exporter.copyAsMarkdown(); exportOpen = false">
               <span class="dropdown__name">{{ t('toolbar.copyMarkdown') }}</span>
             </button>
+            <button class="dropdown__item dropdown__item--single" @mousedown.prevent="exporter.copyAsImage(); exportOpen = false">
+              <span class="dropdown__name">{{ t('toolbar.copyImage') }}</span>
+            </button>
           </div>
         </Teleport>
       </div>
@@ -533,46 +530,6 @@ onBeforeUnmount(() => {
         <span class="ai-rewrite-label">AI</span>
         <span class="ai-rewrite-spark">✨</span>
       </button>
-    </div>
-
-    <div class="toolbar__group">
-      <div class="copy-split">
-        <button
-          class="copy-split__main"
-          @click="exporter.copyAsHtml()"
-          :title="t('toolbar.copyTooltip')"
-        >
-          <Icon name="export" :size="14" />
-          {{ t('toolbar.copy') }}
-        </button>
-        <div class="dropdown">
-          <button
-            ref="copyBtnRef"
-            class="copy-split__arrow"
-            @click="toggleDropdown('copy')"
-            :title="t('toolbar.copyFormats')"
-          >
-            <Icon name="chevron-down" :size="10" />
-          </button>
-          <Teleport to="body">
-            <div v-if="copyOpen" class="dropdown__menu dropdown__menu--narrow copy-dropdown" :style="floatStyle">
-              <button class="dropdown__item dropdown__item--single" @mousedown.prevent="exporter.copyAsHtml(); copyOpen = false">
-                <span class="dropdown__name">{{ '📋 ' + t('toolbar.copyHtml') }}</span>
-                <span class="dropdown__shortcut">⇧⌘C</span>
-              </button>
-              <button class="dropdown__item dropdown__item--single" @mousedown.prevent="exporter.copyAsMarkdown(); copyOpen = false">
-                <span class="dropdown__name">{{ '📝 ' + t('toolbar.copyMarkdown') }}</span>
-              </button>
-              <button class="dropdown__item dropdown__item--single" @mousedown.prevent="exporter.copyAsPlainText(); copyOpen = false">
-                <span class="dropdown__name">{{ '📄 ' + t('toolbar.copyPlain') }}</span>
-              </button>
-              <button class="dropdown__item dropdown__item--single" @mousedown.prevent="exporter.copyAsImage(); copyOpen = false">
-                <span class="dropdown__name">{{ '🖼 ' + t('toolbar.copyImage') }}</span>
-              </button>
-            </div>
-          </Teleport>
-        </div>
-      </div>
     </div>
 
     <div
@@ -862,59 +819,6 @@ onBeforeUnmount(() => {
   display: inline-block;
 }
 
-/* Split copy button: [Copy | ▾] */
-.copy-split {
-  display: inline-flex;
-  align-items: stretch;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  /* NOTE: no overflow:hidden here — it would clip the dropdown menu */
-  position: relative;
-}
-.copy-split__main {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 3px 10px !important;
-  font-size: 12px !important;
-  color: var(--text-muted);
-  border: none;
-  border-radius: 6px 0 0 6px;
-  transition: all 0.15s;
-}
-.copy-split__main:hover {
-  color: var(--accent);
-  background: var(--bg-hover);
-}
-.copy-split__arrow {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  padding: 0 !important;
-  border: none;
-  border-left: 1px solid var(--border);
-  border-radius: 0 6px 6px 0;
-  color: var(--text-faint);
-}
-.copy-split__arrow:hover {
-  color: var(--accent);
-  background: var(--bg-hover);
-}
-/* The menu lives inside `.copy-split > .dropdown`, but if `.dropdown`
- * is `position: relative` here the menu anchors to the 22 px chevron
- * arrow and looks misaligned (issue #31). Demote that one `.dropdown`
- * to static so the menu falls back to the wrapping `.copy-split`
- * (which is relative), letting `right: 0` line up with the right edge
- * of the whole Copy + chevron widget. */
-.copy-split > .dropdown {
-  position: static;
-}
-.copy-dropdown {
-  right: 0;
-  left: auto;
-  min-width: 220px;
-}
 .toolbar__spacer { flex: 1 1 0; min-width: 0; display: flex; align-items: center; justify-content: center; overflow: hidden; }
 .toolbar__doc-name {
   font-size: 12px;

--- a/app/src/i18n/de.ts
+++ b/app/src/i18n/de.ts
@@ -253,6 +253,7 @@ export const de: I18n = {
     closeSaved: 'Alle gespeicherten schließen',
     closeAll: 'Alle Tabs schließen',
     revealInFolder: 'Im Finder anzeigen',
+    revealInFileTree: 'In Dateibaum anzeigen',
   },
   unsaved: {
     title: 'Ungespeicherte Änderungen',

--- a/app/src/i18n/en.ts
+++ b/app/src/i18n/en.ts
@@ -251,6 +251,7 @@ export const en = {
     closeSaved: 'Close All Saved',
     closeAll: 'Close All Tabs',
     revealInFolder: 'Reveal in Finder',
+    revealInFileTree: 'Reveal in File Tree',
   },
   unsaved: {
     title: 'Unsaved Changes',

--- a/app/src/i18n/es.ts
+++ b/app/src/i18n/es.ts
@@ -253,6 +253,7 @@ export const es: I18n = {
     closeSaved: 'Cerrar todas las guardadas',
     closeAll: 'Cerrar todas las pestañas',
     revealInFolder: 'Mostrar en Finder',
+    revealInFileTree: 'Mostrar en árbol de archivos',
   },
   unsaved: {
     title: 'Cambios sin guardar',

--- a/app/src/i18n/fr.ts
+++ b/app/src/i18n/fr.ts
@@ -253,6 +253,7 @@ export const fr: I18n = {
     closeSaved: 'Fermer tous les enregistrés',
     closeAll: 'Fermer tous les onglets',
     revealInFolder: 'Afficher dans le Finder',
+    revealInFileTree: 'Afficher dans l\'arborescence',
   },
   unsaved: {
     title: 'Modifications non enregistrées',

--- a/app/src/i18n/it.ts
+++ b/app/src/i18n/it.ts
@@ -253,6 +253,7 @@ export const it: I18n = {
     closeSaved: 'Chiudi tutte le salvate',
     closeAll: 'Chiudi tutte le schede',
     revealInFolder: 'Mostra nel Finder',
+    revealInFileTree: 'Mostra nell\'albero file',
   },
   unsaved: {
     title: 'Modifiche non salvate',

--- a/app/src/i18n/ja.ts
+++ b/app/src/i18n/ja.ts
@@ -253,6 +253,7 @@ export const ja: I18n = {
     closeSaved: '保存済みをすべて閉じる',
     closeAll: 'すべてのタブを閉じる',
     revealInFolder: 'Finder で表示',
+    revealInFileTree: 'ファイルツリーで表示',
   },
   unsaved: {
     title: '保存されていない変更',

--- a/app/src/i18n/ko.ts
+++ b/app/src/i18n/ko.ts
@@ -253,6 +253,7 @@ export const ko: I18n = {
     closeSaved: '저장된 탭 모두 닫기',
     closeAll: '모든 탭 닫기',
     revealInFolder: 'Finder에서 표시',
+    revealInFileTree: '파일 트리에서 표시',
   },
   unsaved: {
     title: '저장되지 않은 변경 사항',

--- a/app/src/i18n/nl.ts
+++ b/app/src/i18n/nl.ts
@@ -253,6 +253,7 @@ export const nl: I18n = {
     closeSaved: 'Alle opgeslagen sluiten',
     closeAll: 'Alle tabbladen sluiten',
     revealInFolder: 'Toon in Finder',
+    revealInFileTree: 'Toon in bestandsboom',
   },
   unsaved: {
     title: 'Niet-opgeslagen wijzigingen',

--- a/app/src/i18n/pl.ts
+++ b/app/src/i18n/pl.ts
@@ -253,6 +253,7 @@ export const pl: I18n = {
     closeSaved: 'Zamknij wszystkie zapisane',
     closeAll: 'Zamknij wszystkie karty',
     revealInFolder: 'Pokaż w Finderze',
+    revealInFileTree: 'Pokaż w drzewie plików',
   },
   unsaved: {
     title: 'Niezapisane zmiany',

--- a/app/src/i18n/pt.ts
+++ b/app/src/i18n/pt.ts
@@ -255,6 +255,7 @@ export const pt: I18n = {
     closeSaved: 'Fechar todas as salvas',
     closeAll: 'Fechar todas as abas',
     revealInFolder: 'Mostrar no Finder',
+    revealInFileTree: 'Mostrar na árvore de arquivos',
   },
   unsaved: {
     title: 'Alterações não salvas',

--- a/app/src/i18n/sv.ts
+++ b/app/src/i18n/sv.ts
@@ -253,6 +253,7 @@ export const sv: I18n = {
     closeSaved: 'Stäng alla sparade',
     closeAll: 'Stäng alla flikar',
     revealInFolder: 'Visa i Finder',
+    revealInFileTree: 'Visa i filträd',
   },
   unsaved: {
     title: 'Osparade ändringar',

--- a/app/src/i18n/tr.ts
+++ b/app/src/i18n/tr.ts
@@ -253,6 +253,7 @@ export const tr: I18n = {
     closeSaved: 'Kaydedilenleri Kapat',
     closeAll: 'Tüm Sekmeleri Kapat',
     revealInFolder: 'Finder\'da göster',
+    revealInFileTree: 'Dosya ağacında göster',
   },
   unsaved: {
     title: 'Kaydedilmemiş Değişiklikler',

--- a/app/src/i18n/uk.ts
+++ b/app/src/i18n/uk.ts
@@ -253,6 +253,7 @@ export const uk: I18n = {
     closeSaved: 'Закрити всі збережені',
     closeAll: 'Закрити всі вкладки',
     revealInFolder: 'Показати у Finder',
+    revealInFileTree: 'Показати в дереві файлів',
   },
   unsaved: {
     title: 'Незбережені зміни',

--- a/app/src/i18n/zh.ts
+++ b/app/src/i18n/zh.ts
@@ -252,6 +252,7 @@ export const zh: I18n = {
     closeSaved: '关闭所有已保存',
     closeAll: '关闭所有标签',
     revealInFolder: '在文件管理器中显示',
+    revealInFileTree: '在文件树中定位',
   },
   unsaved: {
     title: '有未保存的修改',


### PR DESCRIPTION
现在tab中显示文档的名称，但是大多数时候都显示不下，当打开了多个名称相似的文档时，不太容易一眼知道当前在看哪个文档


## Summary

- 标题栏显示当前激活文档的名称 — 它帮你确认"当前在看哪个文件"。当前激活文档的文件名作为窗口标题,紧贴 `#MD` brand 显示(VSCode / macOS Notes 风格),解决原生标题栏因 `hiddenTitle: true` 不可见的问题
- Tab 右键菜单新增"在文件树中定位"选项,点击后自动打开文件树侧边栏并导航到文件所在目录
- **删除工具栏重复的 Copy 按钮**,将所有复制功能统一到 Export 下拉菜单中

## Changes

### 文档名作为窗口标题(brand 旁)

原生窗口标题被 `hiddenTitle: true` 隐藏,Toolbar 同时承担"标题栏 + 工具栏"双重身份(v4.6 unified titlebar)。文档名需要出现在标题位置而非工具栏空白处。

- `Toolbar.vue`: 在 `toolbar__brand` 之后渲染 `<span class="toolbar__title">`,展示 `tabs.activeTab.fileName`
- 样式:`13px / font-weight: 500 / 主文本色`,max-width 280px + text-overflow ellipsis
- `flex-shrink: 1` 覆盖 toolbar 的 `> * { flex-shrink: 0 }`,窄窗口下标题先收缩再省略,绝不挤掉工具栏按钮
- macOS 上带 `data-tauri-drag-region`,保持窗口可拖拽
- hover tooltip 显示完整 `filePath`

> **设计演进**:首版(c1e1154)把文档名塞在 `toolbar__spacer` 居中位置——视觉上像"挤在按钮之间的次要信息"而非标题。e5fb078 把它移到 brand 旁并加重样式,真正读起来像个窗口标题。

### Tab 右键"在文件树中定位"

- `PaneTabBar.vue`: 新增 `revealInFileTree` action,复用 `settings.toggleFileTree()` + `workspace.setFolder()` 模式
- 14 个 i18n locale 文件添加 `tabMenu.revealInFileTree` 翻译

### 工具栏 Copy 按钮去重

工具栏 Copy 分体按钮(主按钮 Copy as HTML + 下拉 Copy as Markdown/Plain Text/Image)与 Export 下拉菜单中的 Copy as HTML/Plain Text/Markdown 完全重复,调用相同的 `exporter` 方法。

- `Toolbar.vue`: 删除整个 Copy 分体按钮(模板、JS 状态 `copyOpen`/`copyBtnRef`、`toggleDropdown` 分支、~50 行 CSS)
- `Toolbar.vue`: Export 下拉菜单新增 `Copy as Image` 选项(之前仅 Copy 按钮有此功能)
- Export 下拉菜单现在完整包含:Export HTML/DOCX/PDF/PDF Print/Image → 分隔线 → Copy as HTML/Plain Text/Markdown/**Image**

## Test plan

- [ ] 打开多个文档,确认 `#MD` brand 右侧紧贴显示当前文档名,切换 tab 后名称跟随变化
- [ ] 文档名很长时正确 ellipsis(最多 280px),hover 显示完整路径
- [ ] macOS 上文档名区域可拖拽窗口;窄窗口下文档名先收缩,工具栏按钮不被挤出
- [ ] 右键 tab → "在文件树中定位" → 侧边栏打开并导航到文件所在目录
- [ ] 右键 tab → "在文件管理器中显示" → 系统文件管理器打开并选中文件
- [ ] Export 下拉菜单包含:HTML/DOCX/PDF/PDF Print/Image → 分隔线 → Copy HTML/Plain/Markdown/Image
- [ ] 确认每个 Copy 操作正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)