### PR TITLE
feat(editor): Windows 纯文本编辑器补齐功能(撤销/查找/Tab/贴图/任务勾选/换行)

### DIFF
--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -182,6 +182,11 @@ const plainBlocks = computed<PlainBlock[]>(() => {
 });
 
 function renderPlainBlock(src: string): string {
+  // A standalone thematic-break block ("---" / "***" / "___") would be misread
+  // as a YAML front-matter fence when rendered in isolation (each block renders
+  // on its own), producing an empty md-frontmatter element instead of a rule.
+  // Emit the <hr> directly.
+  if (/^\s*(-{3,}|\*{3,}|_{3,})\s*$/.test(src)) return '<hr>';
   const root = extractMarkdownImageRoot(plainText.value || '');
   const key = `${props.tab.filePath || ''}\u0000${root}\u0000${src}`;
   const cached = plainRenderCache.get(key);

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -541,6 +541,18 @@ function plainInsertText(snippet: string) {
   emitPlainCursorAndSelection();
 }
 
+function focusPlainEditor() {
+  // Plain editors don't take focus on their own (the CodeMirror path calls
+  // view.focus()). Without this, a freshly opened/created document has focus on
+  // <body> and keystrokes go nowhere until the user clicks the editor.
+  nextTick(() => {
+    const el = plainLiveEnabled.value
+      ? plainBlockEditors.value[plainActiveBlock.value]
+      : plainEditor.value;
+    el?.focus();
+  });
+}
+
 function syncPlainEditorFromStore(text: string) {
   const el = plainEditor.value;
   plainText.value = text;
@@ -1310,6 +1322,7 @@ onMounted(() => {
     syncPlainEditorFromStore(props.tab.content);
     maybeRestoreSession();
     void processPlainLiveRenderedBlocks();
+    focusPlainEditor();
     return;
   }
   if (!host.value) return;
@@ -1352,6 +1365,21 @@ onBeforeUnmount(() => {
 watch(
   () => props.tab.id,
   () => {
+    if (usePlainWindowsEditor) {
+      // The Editor component is reused across tabs (no :key), so switching to /
+      // creating a document must re-sync content, reset per-document state, and
+      // re-focus — otherwise the new doc shows stale text and can't be typed in.
+      plainActiveBlock.value = 0;
+      plainUndoStack.length = 0;
+      plainRedoStack = [];
+      plainHistoryTs = 0;
+      closePlainFind();
+      syncPlainEditorFromStore(props.tab.content);
+      maybeRestoreSession();
+      void processPlainLiveRenderedBlocks();
+      focusPlainEditor();
+      return;
+    }
     if (!view) return;
     view.setState(
       EditorState.create({ doc: props.tab.content, extensions: buildExtensions() })

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -1029,7 +1029,33 @@ function handlePlainKeydownShared(event: KeyboardEvent): boolean {
     plainRedo();
     return true;
   }
+  // Ctrl/Cmd+J — AI rewrite of the selection (matches cm-ai-rewrite). The
+  // overlay + accept path are shared with the CodeMirror editor; accept replaces
+  // the (retained) selection via the insert-markdown channel.
+  if (!IS_APP_STORE_BUILD && mod && !event.altKey && (event.key === 'j' || event.key === 'J')) {
+    const sel = plainAbsoluteSelection();
+    const text = plainSelectionText();
+    if (sel && text) {
+      event.preventDefault();
+      window.dispatchEvent(
+        new CustomEvent('solomd:ai-rewrite-open', { detail: { selection: text, from: sel.from, to: sel.to } }),
+      );
+      return true;
+    }
+  }
   return false;
+}
+
+function plainAbsoluteSelection(): { from: number; to: number } | null {
+  if (plainLiveEnabled.value) {
+    const el = plainBlockEditors.value[plainActiveBlock.value];
+    const block = plainBlocks.value[plainActiveBlock.value];
+    if (!el || !block) return null;
+    return { from: block.start + (el.selectionStart ?? 0), to: block.start + (el.selectionEnd ?? 0) };
+  }
+  const el = plainEditor.value;
+  if (!el) return null;
+  return { from: el.selectionStart ?? 0, to: el.selectionEnd ?? 0 };
 }
 
 /**

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -153,6 +153,11 @@ const plainBlockEditors = ref<Record<number, HTMLTextAreaElement | null>>({});
 const plainText = ref(props.tab.content || '');
 const plainActiveBlock = ref(0);
 let plainComposing = false;
+// Reactive twin of plainComposing for the template: while an IME composition is
+// active we must show the REAL textarea text (and hide the syntax-highlight
+// overlay), otherwise the composing pinyin/candidates are invisible (the overlay
+// makes textarea text transparent) and CJK input looks broken.
+const plainImeActive = ref(false);
 let plainMermaidIdSeq = 0;
 const plainRenderCache = new Map<string, string>();
 
@@ -1310,10 +1315,12 @@ function handlePlainBlockInput(index: number, event: Event) {
 
 function handlePlainBlockCompositionStart() {
   plainComposing = true;
+  plainImeActive.value = true;
 }
 
 function handlePlainBlockCompositionEnd(index: number, event: CompositionEvent) {
   plainComposing = false;
+  plainImeActive.value = false;
   const el = event.target as HTMLTextAreaElement;
   autoSizePlainBlock(el);
   updatePlainBlock(index, el.value, el.selectionStart ?? el.value.length);
@@ -1928,7 +1935,7 @@ const cls = computed(() => ({
         :class="{ 'plain-block--active': index === plainActiveBlock }"
         @click="(event) => activatePlainBlockFromClick(index, event)"
       >
-        <div v-if="index === plainActiveBlock" class="plain-block__edit">
+        <div v-if="index === plainActiveBlock" class="plain-block__edit" :class="{ 'plain-block__edit--composing': plainImeActive }">
           <pre
             class="plain-block__highlight"
             :class="{ 'plain-textarea--wrap': settings.wordWrap }"
@@ -2249,6 +2256,16 @@ const cls = computed(() => ({
   color: transparent;
   -webkit-text-fill-color: transparent;
   caret-color: var(--accent);
+}
+/* During IME composition show the real textarea text and hide the highlight
+   overlay, so composing pinyin / candidates are visible (transparent text would
+   make CJK input look broken). */
+.plain-block__edit--composing .plain-block__textarea--overlay {
+  color: var(--text);
+  -webkit-text-fill-color: var(--text);
+}
+.plain-block__edit--composing .plain-block__highlight {
+  visibility: hidden;
 }
 /* Markdown token colours (mirror the CodeMirror highlight palette roughly). */
 .plain-block__highlight .md-heading { color: var(--accent, #ff9f40); font-weight: 600; }

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -53,6 +53,8 @@ import {
 } from '../lib/cm-session-restore';
 import { renderMarkdown, extractImageRoot as extractMarkdownImageRoot } from '../lib/markdown';
 import { rewriteImageUrls } from '../lib/image-resolve';
+import { SLASH_BLOCKS, filterBlocks, expandSnippet } from '../lib/slash-blocks';
+import { useWorkspaceIndexStore } from '../stores/workspaceIndex';
 
 type PlainBlock = {
   id: string;
@@ -99,6 +101,7 @@ const emit = defineEmits<{
 
 const tabs = useTabsStore();
 const settings = useSettingsStore();
+const workspaceIndex = useWorkspaceIndexStore();
 const { t } = useI18n();
 const pandoc = usePandocExport();
 let cachedCitations: CitationEntry[] = [];
@@ -825,6 +828,135 @@ function replacePlainAll() {
   nextTick(runPlainSearch);
 }
 
+// ---- Plain editor: autocomplete popup (/ slash commands, [[ wikilinks,
+// # tags, @ citations). Triggers as you type; ↑/↓ navigate, Enter/Tab insert,
+// Esc dismisses. Reuses the same data the CodeMirror editor uses. ----
+type AcKind = 'slash' | 'wikilink' | 'tag' | 'citation';
+interface AcItem { label: string; hint?: string; insert: string; cursorOffset: number }
+const acOpen = ref(false);
+const acItems = ref<AcItem[]>([]);
+const acIndex = ref(0);
+const acPos = ref<{ left: number; top: number }>({ left: 0, top: 0 });
+let acTriggerStart = -1;
+
+function closePlainAutocomplete() {
+  acOpen.value = false;
+  acItems.value = [];
+  acTriggerStart = -1;
+}
+
+function baseNoteName(path: string): string {
+  return (path.split(/[\\/]/).pop() || path).replace(/\.md$/i, '');
+}
+
+function buildAcItems(kind: AcKind, query: string): AcItem[] {
+  const q = query.toLowerCase();
+  if (kind === 'slash') {
+    return filterBlocks(SLASH_BLOCKS, query).slice(0, 8).map((b) => {
+      const ex = expandSnippet(b.snippet, '');
+      return { label: b.label, hint: b.hint, insert: ex.text, cursorOffset: ex.cursorOffset };
+    });
+  }
+  if (kind === 'wikilink') {
+    return (workspaceIndex.entries || [])
+      .map((e) => e.title || baseNoteName(e.path))
+      .filter((n) => n && n.toLowerCase().includes(q))
+      .slice(0, 8)
+      .map((n) => ({ label: n, hint: 'wiki', insert: `[[${n}]]`, cursorOffset: n.length + 4 }));
+  }
+  if (kind === 'tag') {
+    return (workspaceIndex.tags || [])
+      .filter((t) => t.tag.toLowerCase().includes(q))
+      .slice(0, 8)
+      .map((t) => ({ label: `#${t.tag}`, hint: String(t.count), insert: `#${t.tag} `, cursorOffset: t.tag.length + 2 }));
+  }
+  // citation
+  return cachedCitations
+    .filter((c) => (c.key || '').toLowerCase().includes(q))
+    .slice(0, 8)
+    .map((c) => ({ label: `@${c.key}`, hint: (c.title ? String(c.title).slice(0, 32) : ''), insert: `@${c.key} `, cursorOffset: c.key.length + 2 }));
+}
+
+function caretRectFromHighlight(caret: number): { left: number; bottom: number } | null {
+  const el = plainBlockEditors.value[plainActiveBlock.value];
+  const pre = el?.closest('.plain-block__edit')?.querySelector('.plain-block__highlight') as HTMLElement | null;
+  if (!pre) return null;
+  let remaining = caret;
+  let target: Node | null = null;
+  let local = 0;
+  const walker = document.createTreeWalker(pre, NodeFilter.SHOW_TEXT);
+  let n: Node | null = walker.nextNode();
+  while (n) {
+    const len = n.textContent?.length ?? 0;
+    if (remaining <= len) { target = n; local = remaining; break; }
+    remaining -= len;
+    n = walker.nextNode();
+  }
+  const range = document.createRange();
+  try {
+    if (target) range.setStart(target, Math.min(local, target.textContent?.length ?? 0));
+    else { range.selectNodeContents(pre); range.collapse(false); }
+    range.collapse(true);
+  } catch {
+    return null;
+  }
+  const r = range.getBoundingClientRect();
+  return { left: r.left, bottom: r.bottom };
+}
+
+function maybeOpenPlainAutocomplete(el: HTMLTextAreaElement) {
+  if (plainComposing) return;
+  const caret = el.selectionStart ?? 0;
+  const before = el.value.slice(0, caret);
+  let kind: AcKind | null = null;
+  let query = '';
+  let m: RegExpMatchArray | null;
+  if ((m = before.match(/(?:^|\n)[ \t]*\/([^\s/]*)$/))) { kind = 'slash'; query = m[1]; acTriggerStart = caret - m[1].length - 1; }
+  else if ((m = before.match(/\[\[([^\]\n]*)$/))) { kind = 'wikilink'; query = m[1]; acTriggerStart = caret - m[1].length - 2; }
+  else if ((m = before.match(/(?:^|[\s(])#([^\s#]*)$/))) { kind = 'tag'; query = m[1]; acTriggerStart = caret - m[1].length - 1; }
+  else if ((m = before.match(/(?:^|[\s(])@([^\s@]*)$/))) { kind = 'citation'; query = m[1]; acTriggerStart = caret - m[1].length - 1; }
+  if (!kind) { closePlainAutocomplete(); return; }
+  const items = buildAcItems(kind, query);
+  if (!items.length) { closePlainAutocomplete(); return; }
+  acItems.value = items;
+  acIndex.value = 0;
+  acOpen.value = true;
+  nextTick(() => {
+    const rect = caretRectFromHighlight(acTriggerStart);
+    if (rect) acPos.value = { left: Math.round(rect.left), top: Math.round(rect.bottom + 4) };
+  });
+}
+
+function applyPlainAutocomplete(item: AcItem) {
+  const el = plainBlockEditors.value[plainActiveBlock.value];
+  if (!el || acTriggerStart < 0) { closePlainAutocomplete(); return; }
+  const index = plainActiveBlock.value;
+  const caret = el.selectionStart ?? el.value.length;
+  const start = acTriggerStart;
+  const value = el.value.slice(0, start) + item.insert + el.value.slice(caret);
+  const newCaret = start + item.cursorOffset;
+  closePlainAutocomplete();
+  updatePlainBlock(index, value, newCaret);
+  nextTick(() => {
+    const e2 = plainBlockEditors.value[plainActiveBlock.value];
+    if (e2) {
+      e2.focus();
+      const p = Math.min(newCaret, e2.value.length);
+      e2.setSelectionRange(p, p);
+    }
+  });
+}
+
+/** Returns true if the keydown was consumed by the autocomplete popup. */
+function handleAutocompleteKeydown(event: KeyboardEvent): boolean {
+  if (!acOpen.value || !acItems.value.length) return false;
+  if (event.key === 'ArrowDown') { event.preventDefault(); acIndex.value = (acIndex.value + 1) % acItems.value.length; return true; }
+  if (event.key === 'ArrowUp') { event.preventDefault(); acIndex.value = (acIndex.value - 1 + acItems.value.length) % acItems.value.length; return true; }
+  if (event.key === 'Enter' || event.key === 'Tab') { event.preventDefault(); applyPlainAutocomplete(acItems.value[acIndex.value]); return true; }
+  if (event.key === 'Escape') { event.preventDefault(); closePlainAutocomplete(); return true; }
+  return false;
+}
+
 /** Compute a Tab/Shift+Tab indent edit over the textarea's current selection. */
 function computePlainTabEdit(
   el: HTMLTextAreaElement,
@@ -886,6 +1018,7 @@ function handlePlainKeydownShared(event: KeyboardEvent): boolean {
 
 function handlePlainBlockKeydown(index: number, event: KeyboardEvent) {
   if (plainComposing) return;
+  if (handleAutocompleteKeydown(event)) return;
   if (handlePlainKeydownShared(event)) return;
   if (event.key === 'Tab') {
     event.preventDefault();
@@ -1079,6 +1212,7 @@ function handlePlainBlockInput(index: number, event: Event) {
   plainActiveSource.value = el.value; // keep the highlight overlay in sync (also mid-composition)
   if (plainComposing) return;
   updatePlainBlock(index, el.value, el.selectionStart ?? el.value.length);
+  maybeOpenPlainAutocomplete(el);
 }
 
 function handlePlainBlockCompositionStart() {
@@ -1785,6 +1919,25 @@ const cls = computed(() => ({
         <button class="plain-find__btn plain-find__btn--text" @click="replacePlainAll">All</button>
       </div>
     </div>
+
+    <!-- Autocomplete popup (/ slash, [[ wikilink, # tag, @ citation). -->
+    <ul
+      v-if="acOpen && acItems.length"
+      class="plain-ac"
+      :style="{ left: acPos.left + 'px', top: acPos.top + 'px' }"
+    >
+      <li
+        v-for="(item, i) in acItems"
+        :key="i"
+        class="plain-ac__item"
+        :class="{ 'plain-ac__item--active': i === acIndex }"
+        @mousedown.prevent="applyPlainAutocomplete(item)"
+        @mouseenter="acIndex = i"
+      >
+        <span class="plain-ac__label">{{ item.label }}</span>
+        <span v-if="item.hint" class="plain-ac__hint">{{ item.hint }}</span>
+      </li>
+    </ul>
   </div>
 </template>
 
@@ -1866,6 +2019,41 @@ const cls = computed(() => ({
 }
 .plain-find__btn--text {
   font-size: 12px;
+}
+.plain-ac {
+  position: fixed;
+  z-index: 30;
+  margin: 0;
+  padding: 4px;
+  list-style: none;
+  min-width: 180px;
+  max-width: 360px;
+  max-height: 280px;
+  overflow-y: auto;
+  background: var(--bg-elevated, var(--bg));
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.35));
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+}
+.plain-ac__item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 5px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text);
+}
+.plain-ac__item--active {
+  background: var(--accent, #ff9f40);
+  color: var(--accent-fg, #fff);
+}
+.plain-ac__hint {
+  font-size: 11px;
+  opacity: 0.7;
+  white-space: nowrap;
 }
 .plain-editor {
   height: 100%;

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -198,6 +198,52 @@ function renderPlainBlock(src: string): string {
   return html;
 }
 
+// Live source of the active block's textarea, mirrored for the syntax-highlight
+// overlay. Updated on input / activation (including mid-composition).
+const plainActiveSource = ref('');
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/**
+ * Lightweight Markdown syntax highlighter for the active block's source. Returns
+ * HTML (already escaped) with token spans. Deliberately conservative — a few
+ * non-overlapping inline rules so it never mangles text; it sits behind a
+ * transparent <textarea>, so it only needs to colour, not be a full parser.
+ */
+function highlightMarkdownSource(src: string): string {
+  let inFence = false;
+  const lines = src.split('\n').map((raw) => {
+    const fence = /^\s*(```|~~~)/.test(raw);
+    if (fence) {
+      inFence = !inFence;
+      return `<span class="md-fence">${escapeHtml(raw)}</span>`;
+    }
+    if (inFence) return `<span class="md-code">${escapeHtml(raw)}</span>`;
+    if (/^#{1,6}\s/.test(raw)) return `<span class="md-heading">${escapeHtml(raw)}</span>`;
+    if (/^\s*(---|\*\*\*|___)\s*$/.test(raw)) return `<span class="md-hr">${escapeHtml(raw)}</span>`;
+
+    let e = escapeHtml(raw);
+    // Blockquote marker (escaped '>').
+    e = e.replace(/^(\s*)(&gt;)/, '$1<span class="md-quote">$2</span>');
+    // List / ordered-list marker.
+    e = e.replace(/^(\s*)([-*+]|\d+[.)])(\s)/, '$1<span class="md-list">$2</span>$3');
+    // Images then links (image first so the leading ! is included).
+    e = e.replace(/(!?\[[^\]\n]*\]\([^)\n]*\))/g, '<span class="md-link">$1</span>');
+    // Inline code.
+    e = e.replace(/(`[^`\n]+`)/g, '<span class="md-code">$1</span>');
+    // Bold (** or __). Skipped inside already-wrapped spans is acceptable.
+    e = e.replace(/(\*\*[^*\n]+\*\*|__[^_\n]+__)/g, '<span class="md-strong">$1</span>');
+    // Strikethrough.
+    e = e.replace(/(~~[^~\n]+~~)/g, '<span class="md-del">$1</span>');
+    return e;
+  });
+  return lines.join('\n');
+}
+
+const plainActiveHighlight = computed(() => highlightMarkdownSource(plainActiveSource.value));
+
 async function processPlainLiveRenderedBlocks() {
   if (!plainLiveEnabled.value || !plainLiveHost.value) return;
   await nextTick();
@@ -1018,6 +1064,7 @@ function setPlainBlockEditor(index: number, el: HTMLTextAreaElement | null) {
   if (!el) return;
   const block = plainBlocks.value[index];
   if (block && el.value !== block.text) el.value = block.text;
+  if (index === plainActiveBlock.value) plainActiveSource.value = el.value;
   nextTick(() => autoSizePlainBlock(el));
 }
 
@@ -1029,6 +1076,7 @@ function autoSizePlainBlock(el: HTMLTextAreaElement) {
 function handlePlainBlockInput(index: number, event: Event) {
   const el = event.target as HTMLTextAreaElement;
   autoSizePlainBlock(el);
+  plainActiveSource.value = el.value; // keep the highlight overlay in sync (also mid-composition)
   if (plainComposing) return;
   updatePlainBlock(index, el.value, el.selectionStart ?? el.value.length);
 }
@@ -1653,24 +1701,31 @@ const cls = computed(() => ({
         :class="{ 'plain-block--active': index === plainActiveBlock }"
         @click="(event) => activatePlainBlockFromClick(index, event)"
       >
-        <textarea
-          v-if="index === plainActiveBlock"
-          :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
-          class="plain-block__textarea"
-          :class="{ 'plain-textarea--wrap': settings.wordWrap }"
-          :spellcheck="props.spellCheck"
-          :wrap="settings.wordWrap ? 'soft' : 'off'"
-          @keydown="(event) => handlePlainBlockKeydown(index, event)"
-          @paste="handlePlainPaste"
-          @input="(event) => handlePlainBlockInput(index, event)"
-          @compositionstart="handlePlainBlockCompositionStart"
-          @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
-          @click.stop
-          @keyup="emitPlainCursorAndSelection"
-          @mouseup="emitPlainCursorAndSelection"
-          @select="emitPlainCursorAndSelection"
-          @focus="emitPlainCursorAndSelection"
-        ></textarea>
+        <div v-if="index === plainActiveBlock" class="plain-block__edit">
+          <pre
+            class="plain-block__highlight"
+            :class="{ 'plain-textarea--wrap': settings.wordWrap }"
+            aria-hidden="true"
+            v-html="plainActiveHighlight"
+          ></pre>
+          <textarea
+            :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
+            class="plain-block__textarea plain-block__textarea--overlay"
+            :class="{ 'plain-textarea--wrap': settings.wordWrap }"
+            :spellcheck="props.spellCheck"
+            :wrap="settings.wordWrap ? 'soft' : 'off'"
+            @keydown="(event) => handlePlainBlockKeydown(index, event)"
+            @paste="handlePlainPaste"
+            @input="(event) => handlePlainBlockInput(index, event)"
+            @compositionstart="handlePlainBlockCompositionStart"
+            @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
+            @click.stop
+            @keyup="emitPlainCursorAndSelection"
+            @mouseup="emitPlainCursorAndSelection"
+            @select="emitPlainCursorAndSelection"
+            @focus="emitPlainCursorAndSelection"
+          ></textarea>
+        </div>
         <div
           v-else
           class="plain-block__render"
@@ -1875,6 +1930,51 @@ const cls = computed(() => ({
 .plain-block__textarea::selection {
   background: rgba(255, 159, 64, 0.28);
 }
+/* Syntax-highlight overlay: a coloured <pre> behind a transparent <textarea>.
+   Both MUST share identical text metrics so the caret lines up with the glyphs. */
+.plain-block__edit {
+  position: relative;
+}
+.plain-block__highlight {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  border: 0;
+  padding: 0;
+  box-sizing: border-box;
+  width: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  font: inherit;
+  line-height: inherit;
+  tab-size: 2;
+  white-space: pre;
+  color: var(--text);
+  background: transparent;
+  z-index: 0;
+}
+.plain-block__highlight.plain-textarea--wrap {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+}
+.plain-block__textarea--overlay {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: var(--accent);
+}
+/* Markdown token colours (mirror the CodeMirror highlight palette roughly). */
+.plain-block__highlight .md-heading { color: var(--accent, #ff9f40); font-weight: 600; }
+.plain-block__highlight .md-strong { color: var(--text); font-weight: 700; }
+.plain-block__highlight .md-del { color: var(--text-faint, #888); }
+.plain-block__highlight .md-code,
+.plain-block__highlight .md-fence { color: #4ec9b0; }
+.plain-block__highlight .md-link { color: #4aa3ff; }
+.plain-block__highlight .md-list,
+.plain-block__highlight .md-quote { color: var(--accent, #ff9f40); }
+.plain-block__highlight .md-hr { color: var(--text-faint, #888); }
 .plain-block__render {
   color: var(--text);
   overflow: visible;

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -30,7 +30,7 @@ import { liveEditExtension } from '../lib/cm-live-render';
 import { liveBlocksExtension, liveBlocksTheme, extractImageRoot } from '../lib/cm-live-blocks';
 import { findTldrawFences, replaceBoardSnapshot } from '../lib/tldraw-board';
 import { dragAwareExtension } from '../lib/cm-drag-aware';
-import { imagePasteExtension, insertImageFromPath as cmInsertImageFromPath } from '../lib/cm-image-paste';
+import { imagePasteExtension, insertImageFromPath as cmInsertImageFromPath, handleTextareaImagePaste } from '../lib/cm-image-paste';
 import { focusModeExtension, typewriterModeExtension } from '../lib/cm-focus-mode';
 import { wikilinkExtension, wikilinkComplete } from '../lib/cm-wikilink';
 import { tagAutocompleteExtension, tagComplete } from '../lib/cm-tag-autocomplete';
@@ -184,7 +184,12 @@ function renderPlainBlock(src: string): string {
   const cached = plainRenderCache.get(key);
   if (cached != null) return cached;
   const html = rewriteImageUrls(
-    renderMarkdown(src || '\n', { breaks: true }),
+    // Drop `disabled` on task checkboxes so they can be clicked to toggle in the
+    // preview (handled by activatePlainBlockFromClick → togglePlainTask).
+    renderMarkdown(src || '\n', { breaks: true }).replace(
+      /(<input class="task-list-item-checkbox" type="checkbox"[^>]*?)\s+disabled=""/g,
+      '$1',
+    ),
     root,
     props.tab.filePath,
   );
@@ -495,6 +500,22 @@ function syncPlainLiveScroll() {
   emitPlainCursorAndSelection();
 }
 
+function handlePlainPaste(event: ClipboardEvent) {
+  // Clipboard image paste (Ctrl+V of a screenshot). Text paste falls through to
+  // the textarea's native handling. plainInsertText records its own undo step.
+  void handleTextareaImagePaste(
+    event,
+    {
+      getFilePath: () => props.tab.filePath,
+      getDocContent: () => props.tab.content,
+      getAttachmentMode: () => settings.attachmentMode,
+      getAssetsDirName: () => settings.assetsDirName,
+      getCustomPath: () => settings.attachmentCustomPath,
+    },
+    (text) => plainInsertText(text),
+  );
+}
+
 function plainInsertText(snippet: string) {
   if (plainLiveEnabled.value) {
     const index = plainActiveBlock.value;
@@ -508,6 +529,7 @@ function plainInsertText(snippet: string) {
   }
   const el = plainEditor.value;
   if (!el) return;
+  recordPlainHistory();
   const start = el.selectionStart ?? 0;
   const end = el.selectionEnd ?? 0;
   const next = `${el.value.slice(0, start)}${snippet}${el.value.slice(end)}`;
@@ -804,8 +826,45 @@ function estimatePlainBlockCaretFromClick(index: number, event: MouseEvent): num
 }
 
 function activatePlainBlockFromClick(index: number, event: MouseEvent) {
+  // Clicking a rendered task checkbox toggles its source marker instead of
+  // entering edit mode.
+  const target = event.target as HTMLElement | null;
+  if (
+    target instanceof HTMLInputElement &&
+    target.type === 'checkbox' &&
+    target.classList.contains('task-list-item-checkbox')
+  ) {
+    const render = (event.currentTarget as HTMLElement).querySelector('.plain-block__render');
+    const boxes = render
+      ? Array.from(render.querySelectorAll('input.task-list-item-checkbox'))
+      : [];
+    const ordinal = boxes.indexOf(target);
+    event.preventDefault();
+    if (ordinal >= 0) togglePlainTask(index, ordinal);
+    return;
+  }
   if (index === plainActiveBlock.value) return;
   activatePlainBlock(index, estimatePlainBlockCaretFromClick(index, event));
+}
+
+/** Flip the `ordinal`-th task checkbox marker in a block's source, in place. */
+function togglePlainTask(index: number, ordinal: number) {
+  const block = plainBlocks.value[index];
+  if (!block) return;
+  let n = -1;
+  const re = /^(\s*(?:[-*+]|\d+[.)])\s+\[)([ xX])(\])/gm;
+  const newText = block.text.replace(re, (m, pre, mark, post) => {
+    n += 1;
+    if (n !== ordinal) return m;
+    return `${pre}${mark === ' ' ? 'x' : ' '}${post}`;
+  });
+  if (newText === block.text) return;
+  recordPlainHistory();
+  const tail = block.hasTrailingNewline ? '\n' : '';
+  const next =
+    plainText.value.slice(0, block.start) + newText + tail + plainText.value.slice(block.end);
+  plainText.value = next;
+  tabs.setContent(props.tab.id, next);
 }
 
 function activatePlainBlock(index: number, caret?: number) {
@@ -1454,6 +1513,7 @@ const cls = computed(() => ({
         :spellcheck="props.spellCheck"
         :wrap="settings.wordWrap ? 'soft' : 'off'"
         @keydown="(event) => handlePlainBlockKeydown(index, event)"
+        @paste="handlePlainPaste"
         @input="(event) => handlePlainBlockInput(index, event)"
         @compositionstart="handlePlainBlockCompositionStart"
         @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
@@ -1478,6 +1538,7 @@ const cls = computed(() => ({
       :spellcheck="props.spellCheck"
       :wrap="settings.wordWrap ? 'soft' : 'off'"
       @keydown="handlePlainEditorKeydown"
+      @paste="handlePlainPaste"
       @input="handlePlainInput"
       @keyup="emitPlainCursorAndSelection"
       @mouseup="emitPlainCursorAndSelection"

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -653,6 +653,120 @@ function plainRedo() {
   applyPlainContent(next.content, next.caret);
 }
 
+// ---- Plain editor: in-document find / replace (the textarea path has no
+// CodeMirror search panel). Matches are computed over the whole document;
+// navigating selects the match in the right block. ----
+const plainFindOpen = ref(false);
+const plainFindQuery = ref('');
+const plainReplaceValue = ref('');
+const plainFindCaseSensitive = ref(false);
+const plainFindInput = ref<HTMLInputElement | null>(null);
+const plainMatches = ref<Array<{ start: number; end: number }>>([]);
+const plainMatchIndex = ref(0);
+
+function runPlainSearch() {
+  const q = plainFindQuery.value;
+  if (!q) {
+    plainMatches.value = [];
+    plainMatchIndex.value = 0;
+    return;
+  }
+  const hay = plainFindCaseSensitive.value ? plainText.value : plainText.value.toLowerCase();
+  const needle = plainFindCaseSensitive.value ? q : q.toLowerCase();
+  const out: Array<{ start: number; end: number }> = [];
+  let i = hay.indexOf(needle);
+  while (i >= 0) {
+    out.push({ start: i, end: i + q.length });
+    i = hay.indexOf(needle, i + Math.max(1, q.length));
+  }
+  plainMatches.value = out;
+  if (plainMatchIndex.value >= out.length) plainMatchIndex.value = 0;
+}
+
+function openPlainFind() {
+  plainFindOpen.value = true;
+  const selected = plainSelectionText();
+  if (selected && !selected.includes('\n')) plainFindQuery.value = selected;
+  nextTick(() => {
+    plainFindInput.value?.focus();
+    plainFindInput.value?.select();
+    runPlainSearch();
+    if (plainMatches.value.length) gotoPlainMatch(0);
+  });
+}
+
+function closePlainFind() {
+  plainFindOpen.value = false;
+}
+
+function selectPlainRange(start: number, end: number) {
+  if (plainLiveEnabled.value) {
+    const blocks = plainBlocks.value;
+    const bi = blocks.findIndex((b) => start >= b.start && start < b.end);
+    plainActiveBlock.value = bi < 0 ? Math.max(0, blocks.length - 1) : bi;
+    nextTick(() => {
+      const el = plainBlockEditors.value[plainActiveBlock.value];
+      const b = plainBlocks.value[plainActiveBlock.value];
+      if (!el || !b) return;
+      el.focus();
+      const s = Math.max(0, Math.min(start - b.start, el.value.length));
+      const e = Math.max(s, Math.min(end - b.start, el.value.length));
+      el.setSelectionRange(s, e);
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      emitPlainCursorAndSelection();
+    });
+    return;
+  }
+  const el = plainEditor.value;
+  if (!el) return;
+  el.focus();
+  el.setSelectionRange(start, end);
+  emitPlainCursorAndSelection();
+}
+
+function gotoPlainMatch(delta: number) {
+  if (!plainMatches.value.length) {
+    runPlainSearch();
+    if (!plainMatches.value.length) return;
+  }
+  const n = plainMatches.value.length;
+  plainMatchIndex.value = ((plainMatchIndex.value + delta) % n + n) % n;
+  const m = plainMatches.value[plainMatchIndex.value];
+  if (m) selectPlainRange(m.start, m.end);
+}
+
+function replacePlainCurrent() {
+  const m = plainMatches.value[plainMatchIndex.value];
+  if (!m) return;
+  recordPlainHistory();
+  const r = plainReplaceValue.value;
+  const next = plainText.value.slice(0, m.start) + r + plainText.value.slice(m.end);
+  applyPlainContent(next, m.start + r.length);
+  nextTick(() => {
+    runPlainSearch();
+    if (plainMatches.value.length) {
+      if (plainMatchIndex.value >= plainMatches.value.length) plainMatchIndex.value = 0;
+      const nm = plainMatches.value[plainMatchIndex.value];
+      if (nm) selectPlainRange(nm.start, nm.end);
+    }
+  });
+}
+
+function replacePlainAll() {
+  if (!plainFindQuery.value || !plainMatches.value.length) return;
+  recordPlainHistory();
+  const r = plainReplaceValue.value;
+  let result = '';
+  let last = 0;
+  for (const m of plainMatches.value) {
+    result += plainText.value.slice(last, m.start) + r;
+    last = m.end;
+  }
+  result += plainText.value.slice(last);
+  applyPlainContent(result, result.length);
+  nextTick(runPlainSearch);
+}
+
 /** Compute a Tab/Shift+Tab indent edit over the textarea's current selection. */
 function computePlainTabEdit(
   el: HTMLTextAreaElement,
@@ -693,6 +807,11 @@ function computePlainTabEdit(
 /** Shared keydown handling (undo/redo, Tab indent) for the plain editors. */
 function handlePlainKeydownShared(event: KeyboardEvent): boolean {
   const mod = event.ctrlKey || event.metaKey;
+  if (mod && !event.altKey && (event.key === 'f' || event.key === 'F')) {
+    event.preventDefault();
+    openPlainFind();
+    return true;
+  }
   if (mod && !event.altKey && (event.key === 'z' || event.key === 'Z')) {
     event.preventDefault();
     if (event.shiftKey) plainRedo();
@@ -1497,54 +1616,92 @@ const cls = computed(() => ({
 
 <template>
   <div v-if="!usePlainWindowsEditor" :class="cls" ref="host"></div>
-  <div v-else-if="plainLiveEnabled" ref="plainLiveHost" :class="[cls, 'plain-block-editor']" :style="plainEditorStyle">
-    <div
-      v-for="(block, index) in plainBlocks"
-      :key="block.id"
-      class="plain-block"
-      :class="{ 'plain-block--active': index === plainActiveBlock }"
-      @click="(event) => activatePlainBlockFromClick(index, event)"
-    >
+  <div v-else class="plain-host">
+    <div v-if="plainLiveEnabled" ref="plainLiveHost" :class="[cls, 'plain-block-editor']" :style="plainEditorStyle">
+      <div
+        v-for="(block, index) in plainBlocks"
+        :key="block.id"
+        class="plain-block"
+        :class="{ 'plain-block--active': index === plainActiveBlock }"
+        @click="(event) => activatePlainBlockFromClick(index, event)"
+      >
+        <textarea
+          v-if="index === plainActiveBlock"
+          :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
+          class="plain-block__textarea"
+          :class="{ 'plain-textarea--wrap': settings.wordWrap }"
+          :spellcheck="props.spellCheck"
+          :wrap="settings.wordWrap ? 'soft' : 'off'"
+          @keydown="(event) => handlePlainBlockKeydown(index, event)"
+          @paste="handlePlainPaste"
+          @input="(event) => handlePlainBlockInput(index, event)"
+          @compositionstart="handlePlainBlockCompositionStart"
+          @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
+          @click.stop
+          @keyup="emitPlainCursorAndSelection"
+          @mouseup="emitPlainCursorAndSelection"
+          @select="emitPlainCursorAndSelection"
+          @focus="emitPlainCursorAndSelection"
+        ></textarea>
+        <div
+          v-else
+          class="plain-block__render"
+          v-html="block.html"
+        ></div>
+      </div>
+    </div>
+    <div v-else :class="cls" :style="plainEditorStyle">
       <textarea
-        v-if="index === plainActiveBlock"
-        :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
-        class="plain-block__textarea"
+        ref="plainEditor"
+        class="plain-editor"
         :class="{ 'plain-textarea--wrap': settings.wordWrap }"
         :spellcheck="props.spellCheck"
         :wrap="settings.wordWrap ? 'soft' : 'off'"
-        @keydown="(event) => handlePlainBlockKeydown(index, event)"
+        @keydown="handlePlainEditorKeydown"
         @paste="handlePlainPaste"
-        @input="(event) => handlePlainBlockInput(index, event)"
-        @compositionstart="handlePlainBlockCompositionStart"
-        @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
-        @click.stop
+        @input="handlePlainInput"
         @keyup="emitPlainCursorAndSelection"
         @mouseup="emitPlainCursorAndSelection"
         @select="emitPlainCursorAndSelection"
         @focus="emitPlainCursorAndSelection"
       ></textarea>
-      <div
-        v-else
-        class="plain-block__render"
-        v-html="block.html"
-      ></div>
     </div>
-  </div>
-  <div v-else :class="cls" :style="plainEditorStyle">
-    <textarea
-      ref="plainEditor"
-      class="plain-editor"
-      :class="{ 'plain-textarea--wrap': settings.wordWrap }"
-      :spellcheck="props.spellCheck"
-      :wrap="settings.wordWrap ? 'soft' : 'off'"
-      @keydown="handlePlainEditorKeydown"
-      @paste="handlePlainPaste"
-      @input="handlePlainInput"
-      @keyup="emitPlainCursorAndSelection"
-      @mouseup="emitPlainCursorAndSelection"
-      @select="emitPlainCursorAndSelection"
-      @focus="emitPlainCursorAndSelection"
-    ></textarea>
+
+    <!-- In-document find / replace (Ctrl+F). The textarea path has no CodeMirror
+         search panel, so this provides one. -->
+    <div v-if="plainFindOpen" class="plain-find" @keydown.esc.prevent.stop="closePlainFind">
+      <div class="plain-find__row">
+        <input
+          ref="plainFindInput"
+          class="plain-find__input"
+          :value="plainFindQuery"
+          placeholder="Find"
+          @input="(e) => { plainFindQuery = (e.target as HTMLInputElement).value; runPlainSearch(); }"
+          @keydown.enter.prevent="gotoPlainMatch(1)"
+        />
+        <span class="plain-find__count">{{ plainMatches.length ? (plainMatchIndex + 1) + '/' + plainMatches.length : '0/0' }}</span>
+        <button class="plain-find__btn" title="Previous (Shift+Enter)" @click="gotoPlainMatch(-1)">‹</button>
+        <button class="plain-find__btn" title="Next (Enter)" @click="gotoPlainMatch(1)">›</button>
+        <button
+          class="plain-find__btn"
+          :class="{ 'plain-find__btn--on': plainFindCaseSensitive }"
+          title="Match case"
+          @click="plainFindCaseSensitive = !plainFindCaseSensitive; runPlainSearch()"
+        >Aa</button>
+        <button class="plain-find__btn" title="Close (Esc)" @click="closePlainFind">✕</button>
+      </div>
+      <div class="plain-find__row">
+        <input
+          class="plain-find__input"
+          :value="plainReplaceValue"
+          placeholder="Replace"
+          @input="(e) => plainReplaceValue = (e.target as HTMLInputElement).value"
+          @keydown.enter.prevent="replacePlainCurrent"
+        />
+        <button class="plain-find__btn plain-find__btn--text" @click="replacePlainCurrent">Replace</button>
+        <button class="plain-find__btn plain-find__btn--text" @click="replacePlainAll">All</button>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -1561,6 +1718,71 @@ const cls = computed(() => ({
 }
 :deep(.cm-editor.cm-focused) {
   outline: none;
+}
+.plain-host {
+  position: relative;
+  height: 100%;
+  width: 100%;
+}
+.plain-find {
+  position: absolute;
+  top: 8px;
+  right: 16px;
+  z-index: 20;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--bg-elevated, var(--bg));
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.35));
+  border-radius: 8px;
+  padding: 6px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+}
+.plain-find__row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.plain-find__input {
+  width: 200px;
+  padding: 4px 8px;
+  border: 1px solid var(--border, rgba(127, 127, 127, 0.35));
+  border-radius: 5px;
+  background: var(--bg);
+  color: var(--text);
+  font-size: 13px;
+  outline: none;
+}
+.plain-find__input:focus {
+  border-color: var(--accent, #ff9f40);
+}
+.plain-find__count {
+  font-size: 12px;
+  color: var(--text-faint, #888);
+  min-width: 40px;
+  text-align: center;
+}
+.plain-find__btn {
+  min-width: 26px;
+  height: 26px;
+  padding: 0 6px;
+  border: 1px solid transparent;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  font-size: 14px;
+  line-height: 1;
+}
+.plain-find__btn:hover {
+  background: var(--bg-hover, rgba(127, 127, 127, 0.15));
+}
+.plain-find__btn--on {
+  color: var(--accent, #ff9f40);
+  border-color: var(--accent, #ff9f40);
+}
+.plain-find__btn--text {
+  font-size: 12px;
 }
 .plain-editor {
   height: 100%;

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -153,11 +153,6 @@ const plainBlockEditors = ref<Record<number, HTMLTextAreaElement | null>>({});
 const plainText = ref(props.tab.content || '');
 const plainActiveBlock = ref(0);
 let plainComposing = false;
-// Reactive twin of plainComposing for the template: while an IME composition is
-// active we must show the REAL textarea text (and hide the syntax-highlight
-// overlay), otherwise the composing pinyin/candidates are invisible (the overlay
-// makes textarea text transparent) and CJK input looks broken.
-const plainImeActive = ref(false);
 let plainMermaidIdSeq = 0;
 const plainRenderCache = new Map<string, string>();
 
@@ -206,51 +201,6 @@ function renderPlainBlock(src: string): string {
   return html;
 }
 
-// Live source of the active block's textarea, mirrored for the syntax-highlight
-// overlay. Updated on input / activation (including mid-composition).
-const plainActiveSource = ref('');
-
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-/**
- * Lightweight Markdown syntax highlighter for the active block's source. Returns
- * HTML (already escaped) with token spans. Deliberately conservative — a few
- * non-overlapping inline rules so it never mangles text; it sits behind a
- * transparent <textarea>, so it only needs to colour, not be a full parser.
- */
-function highlightMarkdownSource(src: string): string {
-  let inFence = false;
-  const lines = src.split('\n').map((raw) => {
-    const fence = /^\s*(```|~~~)/.test(raw);
-    if (fence) {
-      inFence = !inFence;
-      return `<span class="md-fence">${escapeHtml(raw)}</span>`;
-    }
-    if (inFence) return `<span class="md-code">${escapeHtml(raw)}</span>`;
-    if (/^#{1,6}\s/.test(raw)) return `<span class="md-heading">${escapeHtml(raw)}</span>`;
-    if (/^\s*(---|\*\*\*|___)\s*$/.test(raw)) return `<span class="md-hr">${escapeHtml(raw)}</span>`;
-
-    let e = escapeHtml(raw);
-    // Blockquote marker (escaped '>').
-    e = e.replace(/^(\s*)(&gt;)/, '$1<span class="md-quote">$2</span>');
-    // List / ordered-list marker.
-    e = e.replace(/^(\s*)([-*+]|\d+[.)])(\s)/, '$1<span class="md-list">$2</span>$3');
-    // Images then links (image first so the leading ! is included).
-    e = e.replace(/(!?\[[^\]\n]*\]\([^)\n]*\))/g, '<span class="md-link">$1</span>');
-    // Inline code.
-    e = e.replace(/(`[^`\n]+`)/g, '<span class="md-code">$1</span>');
-    // Bold (** or __). Skipped inside already-wrapped spans is acceptable.
-    e = e.replace(/(\*\*[^*\n]+\*\*|__[^_\n]+__)/g, '<span class="md-strong">$1</span>');
-    // Strikethrough.
-    e = e.replace(/(~~[^~\n]+~~)/g, '<span class="md-del">$1</span>');
-    return e;
-  });
-  return lines.join('\n');
-}
-
-const plainActiveHighlight = computed(() => highlightMarkdownSource(plainActiveSource.value));
 
 async function processPlainLiveRenderedBlocks() {
   if (!plainLiveEnabled.value || !plainLiveHost.value) return;
@@ -898,31 +848,14 @@ function buildAcItems(kind: AcKind, query: string): AcItem[] {
     .map((c) => ({ label: `@${c.key}`, hint: (c.title ? String(c.title).slice(0, 32) : ''), insert: `@${c.key} `, cursorOffset: c.key.length + 2 }));
 }
 
-function caretRectFromHighlight(caret: number): { left: number; bottom: number } | null {
+function caretRectFromHighlight(_caret: number): { left: number; bottom: number } | null {
+  // Anchor the autocomplete popup to the active block's textarea (bottom-left).
+  // A textarea can't give per-caret pixel coords without a mirror element, and
+  // blocks are short, so anchoring below the block is accurate enough.
   const el = plainBlockEditors.value[plainActiveBlock.value];
-  const pre = el?.closest('.plain-block__edit')?.querySelector('.plain-block__highlight') as HTMLElement | null;
-  if (!pre) return null;
-  let remaining = caret;
-  let target: Node | null = null;
-  let local = 0;
-  const walker = document.createTreeWalker(pre, NodeFilter.SHOW_TEXT);
-  let n: Node | null = walker.nextNode();
-  while (n) {
-    const len = n.textContent?.length ?? 0;
-    if (remaining <= len) { target = n; local = remaining; break; }
-    remaining -= len;
-    n = walker.nextNode();
-  }
-  const range = document.createRange();
-  try {
-    if (target) range.setStart(target, Math.min(local, target.textContent?.length ?? 0));
-    else { range.selectNodeContents(pre); range.collapse(false); }
-    range.collapse(true);
-  } catch {
-    return null;
-  }
-  const r = range.getBoundingClientRect();
-  return { left: r.left, bottom: r.bottom };
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { left: r.left, bottom: r.top + Math.min(r.height, 24) };
 }
 
 function maybeOpenPlainAutocomplete(el: HTMLTextAreaElement) {
@@ -1295,7 +1228,6 @@ function setPlainBlockEditor(index: number, el: HTMLTextAreaElement | null) {
   if (!el) return;
   const block = plainBlocks.value[index];
   if (block && el.value !== block.text) el.value = block.text;
-  if (index === plainActiveBlock.value) plainActiveSource.value = el.value;
   nextTick(() => autoSizePlainBlock(el));
 }
 
@@ -1307,7 +1239,6 @@ function autoSizePlainBlock(el: HTMLTextAreaElement) {
 function handlePlainBlockInput(index: number, event: Event) {
   const el = event.target as HTMLTextAreaElement;
   autoSizePlainBlock(el);
-  plainActiveSource.value = el.value; // keep the highlight overlay in sync (also mid-composition)
   if (plainComposing) return;
   updatePlainBlock(index, el.value, el.selectionStart ?? el.value.length);
   maybeOpenPlainAutocomplete(el);
@@ -1315,12 +1246,10 @@ function handlePlainBlockInput(index: number, event: Event) {
 
 function handlePlainBlockCompositionStart() {
   plainComposing = true;
-  plainImeActive.value = true;
 }
 
 function handlePlainBlockCompositionEnd(index: number, event: CompositionEvent) {
   plainComposing = false;
-  plainImeActive.value = false;
   const el = event.target as HTMLTextAreaElement;
   autoSizePlainBlock(el);
   updatePlainBlock(index, el.value, el.selectionStart ?? el.value.length);
@@ -1935,31 +1864,24 @@ const cls = computed(() => ({
         :class="{ 'plain-block--active': index === plainActiveBlock }"
         @click="(event) => activatePlainBlockFromClick(index, event)"
       >
-        <div v-if="index === plainActiveBlock" class="plain-block__edit" :class="{ 'plain-block__edit--composing': plainImeActive }">
-          <pre
-            class="plain-block__highlight"
-            :class="{ 'plain-textarea--wrap': settings.wordWrap }"
-            aria-hidden="true"
-            v-html="plainActiveHighlight"
-          ></pre>
-          <textarea
-            :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
-            class="plain-block__textarea plain-block__textarea--overlay"
-            :class="{ 'plain-textarea--wrap': settings.wordWrap }"
-            :spellcheck="props.spellCheck"
-            :wrap="settings.wordWrap ? 'soft' : 'off'"
-            @keydown="(event) => handlePlainBlockKeydown(index, event)"
-            @paste="handlePlainPaste"
-            @input="(event) => handlePlainBlockInput(index, event)"
-            @compositionstart="handlePlainBlockCompositionStart"
-            @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
-            @click.stop
-            @keyup="emitPlainCursorAndSelection"
-            @mouseup="emitPlainCursorAndSelection"
-            @select="emitPlainCursorAndSelection"
-            @focus="emitPlainCursorAndSelection"
-          ></textarea>
-        </div>
+        <textarea
+          v-if="index === plainActiveBlock"
+          :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
+          class="plain-block__textarea"
+          :class="{ 'plain-textarea--wrap': settings.wordWrap }"
+          :spellcheck="props.spellCheck"
+          :wrap="settings.wordWrap ? 'soft' : 'off'"
+          @keydown="(event) => handlePlainBlockKeydown(index, event)"
+          @paste="handlePlainPaste"
+          @input="(event) => handlePlainBlockInput(index, event)"
+          @compositionstart="handlePlainBlockCompositionStart"
+          @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
+          @click.stop
+          @keyup="emitPlainCursorAndSelection"
+          @mouseup="emitPlainCursorAndSelection"
+          @select="emitPlainCursorAndSelection"
+          @focus="emitPlainCursorAndSelection"
+        ></textarea>
         <div
           v-else
           class="plain-block__render"
@@ -2222,61 +2144,6 @@ const cls = computed(() => ({
 .plain-block__textarea::selection {
   background: rgba(255, 159, 64, 0.28);
 }
-/* Syntax-highlight overlay: a coloured <pre> behind a transparent <textarea>.
-   Both MUST share identical text metrics so the caret lines up with the glyphs. */
-.plain-block__edit {
-  position: relative;
-}
-.plain-block__highlight {
-  position: absolute;
-  inset: 0;
-  margin: 0;
-  border: 0;
-  padding: 0;
-  box-sizing: border-box;
-  width: 100%;
-  overflow: hidden;
-  pointer-events: none;
-  font: inherit;
-  line-height: inherit;
-  tab-size: 2;
-  white-space: pre;
-  color: var(--text);
-  background: transparent;
-  z-index: 0;
-}
-.plain-block__highlight.plain-textarea--wrap {
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
-}
-.plain-block__textarea--overlay {
-  position: relative;
-  z-index: 1;
-  background: transparent;
-  color: transparent;
-  -webkit-text-fill-color: transparent;
-  caret-color: var(--accent);
-}
-/* During IME composition show the real textarea text and hide the highlight
-   overlay, so composing pinyin / candidates are visible (transparent text would
-   make CJK input look broken). */
-.plain-block__edit--composing .plain-block__textarea--overlay {
-  color: var(--text);
-  -webkit-text-fill-color: var(--text);
-}
-.plain-block__edit--composing .plain-block__highlight {
-  visibility: hidden;
-}
-/* Markdown token colours (mirror the CodeMirror highlight palette roughly). */
-.plain-block__highlight .md-heading { color: var(--accent, #ff9f40); font-weight: 600; }
-.plain-block__highlight .md-strong { color: var(--text); font-weight: 700; }
-.plain-block__highlight .md-del { color: var(--text-faint, #888); }
-.plain-block__highlight .md-code,
-.plain-block__highlight .md-fence { color: #4ec9b0; }
-.plain-block__highlight .md-link { color: #4aa3ff; }
-.plain-block__highlight .md-list,
-.plain-block__highlight .md-quote { color: var(--accent, #ff9f40); }
-.plain-block__highlight .md-hr { color: var(--text-faint, #888); }
 .plain-block__render {
   color: var(--text);
   overflow: visible;

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -128,6 +128,12 @@ const typewriterCompartment = new Compartment();
 const vimCompartment = new Compartment();
 const slashCompartment = new Compartment();
 const isWindows = typeof navigator !== 'undefined' && /Win/i.test(navigator.platform);
+// Windows uses the plain-textarea editor: WebView2 + contentEditable drops the
+// first IME character and doubles CJK punctuation (worst on Sogou), and even
+// freezing CodeMirror's decorations during composition does not fix it — the
+// bug is in WebView2's contentEditable IME handling itself. A plain <textarea>
+// relies on the browser's native IME path and avoids both. (Verified: a
+// CodeMirror spike on Windows still ate the first char + doubled punctuation.)
 const usePlainWindowsEditor = isWindows;
 
 function syncEditorContentSoon(text: string) {
@@ -546,10 +552,174 @@ function syncPlainEditorAfterModeSwitch() {
 function handlePlainInput(event: Event) {
   if (plainLiveEnabled.value) return;
   const el = event.target as HTMLTextAreaElement;
+  if (!plainComposing) recordPlainHistory();
   plainText.value = el.value;
   tabs.setContent(props.tab.id, el.value);
   emitPlainCursorAndSelection();
   nextTick(syncPlainLiveScroll);
+}
+
+// ---- Plain editor: document-level undo/redo (the WebView2-safe textarea path
+// has no CodeMirror history). Snapshots are the whole document + an absolute
+// caret offset, with rapid edits coalesced into one step. ----
+type PlainSnapshot = { content: string; caret: number };
+const plainUndoStack: PlainSnapshot[] = [];
+let plainRedoStack: PlainSnapshot[] = [];
+let plainHistoryTs = 0;
+
+function plainAbsoluteCaret(): number {
+  if (plainLiveEnabled.value) {
+    const el = plainBlockEditors.value[plainActiveBlock.value];
+    const block = plainBlocks.value[plainActiveBlock.value];
+    if (!el || !block) return plainText.value.length;
+    return block.start + (el.selectionStart ?? 0);
+  }
+  const el = plainEditor.value;
+  return el ? el.selectionStart ?? el.value.length : plainText.value.length;
+}
+
+function recordPlainHistory() {
+  const now = Date.now();
+  const top = plainUndoStack[plainUndoStack.length - 1];
+  if (top && top.content === plainText.value) {
+    plainHistoryTs = now;
+    return;
+  }
+  // Coalesce bursts of typing into a single undo step.
+  if (plainUndoStack.length && now - plainHistoryTs < 500) {
+    plainHistoryTs = now;
+    return;
+  }
+  plainUndoStack.push({ content: plainText.value, caret: plainAbsoluteCaret() });
+  if (plainUndoStack.length > 300) plainUndoStack.shift();
+  plainRedoStack = [];
+  plainHistoryTs = now;
+}
+
+function applyPlainContent(content: string, caret: number) {
+  plainText.value = content;
+  tabs.setContent(props.tab.id, content);
+  const safe = Math.max(0, Math.min(caret, content.length));
+  if (!plainLiveEnabled.value) {
+    nextTick(() => {
+      const el = plainEditor.value;
+      if (el) {
+        if (el.value !== content) el.value = content;
+        el.focus();
+        el.setSelectionRange(safe, safe);
+      }
+      emitPlainCursorAndSelection();
+    });
+    return;
+  }
+  nextTick(() => plainSetCaret(safe));
+}
+
+function plainUndo() {
+  if (!plainUndoStack.length) return;
+  plainRedoStack.push({ content: plainText.value, caret: plainAbsoluteCaret() });
+  const prev = plainUndoStack.pop() as PlainSnapshot;
+  plainHistoryTs = 0;
+  applyPlainContent(prev.content, prev.caret);
+}
+
+function plainRedo() {
+  if (!plainRedoStack.length) return;
+  plainUndoStack.push({ content: plainText.value, caret: plainAbsoluteCaret() });
+  const next = plainRedoStack.pop() as PlainSnapshot;
+  plainHistoryTs = 0;
+  applyPlainContent(next.content, next.caret);
+}
+
+/** Compute a Tab/Shift+Tab indent edit over the textarea's current selection. */
+function computePlainTabEdit(
+  el: HTMLTextAreaElement,
+  outdent: boolean,
+): { value: string; selStart: number; selEnd: number } {
+  const INDENT = '  ';
+  const v = el.value;
+  const s = el.selectionStart ?? 0;
+  const e = el.selectionEnd ?? 0;
+  if (!outdent && s === e) {
+    return { value: v.slice(0, s) + INDENT + v.slice(e), selStart: s + INDENT.length, selEnd: s + INDENT.length };
+  }
+  const lineStart = v.lastIndexOf('\n', s - 1) + 1;
+  const nl = v.indexOf('\n', e);
+  const lineEnd = nl < 0 ? v.length : nl;
+  const region = v.slice(lineStart, lineEnd);
+  const lines = region.split('\n');
+  let deltaFirst = 0;
+  let deltaTotal = 0;
+  const newLines = lines.map((ln, i) => {
+    if (outdent) {
+      const m = ln.match(/^( {1,2}|\t)/);
+      const removed = m ? m[0].length : 0;
+      if (i === 0) deltaFirst = -removed;
+      deltaTotal -= removed;
+      return ln.slice(removed);
+    }
+    if (i === 0) deltaFirst = INDENT.length;
+    deltaTotal += INDENT.length;
+    return INDENT + ln;
+  });
+  const value = v.slice(0, lineStart) + newLines.join('\n') + v.slice(lineEnd);
+  const selStart = Math.max(lineStart, s + deltaFirst);
+  const selEnd = Math.max(selStart, e + deltaTotal);
+  return { value, selStart, selEnd };
+}
+
+/** Shared keydown handling (undo/redo, Tab indent) for the plain editors. */
+function handlePlainKeydownShared(event: KeyboardEvent): boolean {
+  const mod = event.ctrlKey || event.metaKey;
+  if (mod && !event.altKey && (event.key === 'z' || event.key === 'Z')) {
+    event.preventDefault();
+    if (event.shiftKey) plainRedo();
+    else plainUndo();
+    return true;
+  }
+  if (mod && !event.altKey && (event.key === 'y' || event.key === 'Y')) {
+    event.preventDefault();
+    plainRedo();
+    return true;
+  }
+  return false;
+}
+
+function handlePlainBlockKeydown(index: number, event: KeyboardEvent) {
+  if (plainComposing) return;
+  if (handlePlainKeydownShared(event)) return;
+  if (event.key === 'Tab') {
+    event.preventDefault();
+    const el = event.target as HTMLTextAreaElement;
+    const edit = computePlainTabEdit(el, event.shiftKey);
+    updatePlainBlock(index, edit.value, edit.selStart);
+    // updatePlainBlock's fast path may skip caret restore (block text unchanged
+    // in length-mapping terms); force the selection so the caret follows the
+    // indent and a range stays selected for repeated Tab.
+    nextTick(() => {
+      const e2 = plainBlockEditors.value[plainActiveBlock.value];
+      if (e2) {
+        e2.focus();
+        e2.setSelectionRange(edit.selStart, edit.selEnd);
+      }
+    });
+  }
+}
+
+function handlePlainEditorKeydown(event: KeyboardEvent) {
+  if (plainComposing) return;
+  if (handlePlainKeydownShared(event)) return;
+  if (event.key === 'Tab') {
+    event.preventDefault();
+    const el = event.target as HTMLTextAreaElement;
+    const edit = computePlainTabEdit(el, event.shiftKey);
+    recordPlainHistory();
+    el.value = edit.value;
+    el.setSelectionRange(edit.selStart, edit.selEnd);
+    plainText.value = edit.value;
+    tabs.setContent(props.tab.id, edit.value);
+    emitPlainCursorAndSelection();
+  }
 }
 
 /**
@@ -687,6 +857,8 @@ function handlePlainBlockCompositionEnd(index: number, event: CompositionEvent) 
 function updatePlainBlock(index: number, text: string, caret?: number) {
   const block = plainBlocks.value[index];
   if (!block) return;
+  // Snapshot the pre-edit document for undo (coalesced) before we mutate it.
+  if (!plainComposing) recordPlainHistory();
   const nextCaret = block.start + (caret ?? text.length);
   // Re-attach the block separator that splitPlainMarkdownBlocks stripped from
   // the editable text, so neighbouring blocks don't merge on every edit.
@@ -1279,8 +1451,9 @@ const cls = computed(() => ({
         :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
         class="plain-block__textarea"
         :class="{ 'plain-textarea--wrap': settings.wordWrap }"
-        spellcheck="false"
+        :spellcheck="props.spellCheck"
         :wrap="settings.wordWrap ? 'soft' : 'off'"
+        @keydown="(event) => handlePlainBlockKeydown(index, event)"
         @input="(event) => handlePlainBlockInput(index, event)"
         @compositionstart="handlePlainBlockCompositionStart"
         @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
@@ -1302,8 +1475,9 @@ const cls = computed(() => ({
       ref="plainEditor"
       class="plain-editor"
       :class="{ 'plain-textarea--wrap': settings.wordWrap }"
-      spellcheck="false"
+      :spellcheck="props.spellCheck"
       :wrap="settings.wordWrap ? 'soft' : 'off'"
+      @keydown="handlePlainEditorKeydown"
       @input="handlePlainInput"
       @keyup="emitPlainCursorAndSelection"
       @mouseup="emitPlainCursorAndSelection"

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -1856,7 +1856,7 @@ const cls = computed(() => ({
 <template>
   <div v-if="!usePlainWindowsEditor" :class="cls" ref="host"></div>
   <div v-else class="plain-host">
-    <div v-if="plainLiveEnabled" ref="plainLiveHost" :class="[cls, 'plain-block-editor', { 'plain-focus': props.focusMode }]" :style="plainEditorStyle">
+    <div v-if="plainLiveEnabled" ref="plainLiveHost" :class="[cls, 'plain-block-editor']" :style="plainEditorStyle">
       <div
         v-for="(block, index) in plainBlocks"
         :key="block.id"
@@ -2098,10 +2098,6 @@ const cls = computed(() => ({
   white-space: pre-wrap;
   overflow-wrap: break-word;
   overflow-x: hidden;
-}
-.plain-block-editor.plain-focus .plain-block:not(.plain-block--active) {
-  opacity: 0.35;
-  transition: opacity 0.25s ease;
 }
 .plain-block-editor {
   overflow: auto;

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -1278,8 +1278,9 @@ const cls = computed(() => ({
         v-if="index === plainActiveBlock"
         :ref="(el) => setPlainBlockEditor(index, el as HTMLTextAreaElement | null)"
         class="plain-block__textarea"
+        :class="{ 'plain-textarea--wrap': settings.wordWrap }"
         spellcheck="false"
-        wrap="off"
+        :wrap="settings.wordWrap ? 'soft' : 'off'"
         @input="(event) => handlePlainBlockInput(index, event)"
         @compositionstart="handlePlainBlockCompositionStart"
         @compositionend="(event) => handlePlainBlockCompositionEnd(index, event)"
@@ -1300,8 +1301,9 @@ const cls = computed(() => ({
     <textarea
       ref="plainEditor"
       class="plain-editor"
+      :class="{ 'plain-textarea--wrap': settings.wordWrap }"
       spellcheck="false"
-      wrap="off"
+      :wrap="settings.wordWrap ? 'soft' : 'off'"
       @input="handlePlainInput"
       @keyup="emitPlainCursorAndSelection"
       @mouseup="emitPlainCursorAndSelection"
@@ -1342,6 +1344,11 @@ const cls = computed(() => ({
   white-space: pre;
   overflow: auto;
 }
+.plain-editor.plain-textarea--wrap {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  overflow-x: hidden;
+}
 .plain-block-editor {
   overflow: auto;
   padding: 12px 16px 80px;
@@ -1375,6 +1382,10 @@ const cls = computed(() => ({
   line-height: inherit;
   tab-size: 2;
   white-space: pre;
+}
+.plain-block__textarea.plain-textarea--wrap {
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
 }
 .plain-block__textarea::selection {
   background: rgba(255, 159, 64, 0.28);

--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -482,6 +482,7 @@ function emitPlainCursorAndSelection() {
     const col = lines[lines.length - 1]?.length ?? 0;
     emit('cursor', line, col + 1);
     emit('selection', plainSelectionText());
+    maybeTypewriterScroll();
     return;
   }
   const el = plainEditor.value;
@@ -492,6 +493,21 @@ function emitPlainCursorAndSelection() {
   const col = lines[lines.length - 1]?.length ?? 0;
   emit('cursor', line, col + 1);
   emit('selection', plainSelectionText());
+}
+
+// Typewriter mode: keep the active block vertically centred (matches the
+// CodeMirror typewriterModeExtension).
+function maybeTypewriterScroll() {
+  if (!props.typewriterMode || !plainLiveEnabled.value) return;
+  nextTick(() => {
+    const host = plainLiveHost.value;
+    const el = plainBlockEditors.value[plainActiveBlock.value];
+    if (!host || !el) return;
+    const hostRect = host.getBoundingClientRect();
+    const elRect = el.getBoundingClientRect();
+    const delta = elRect.top + elRect.height / 2 - (hostRect.top + hostRect.height / 2);
+    if (Math.abs(delta) > 1) host.scrollTop += delta;
+  });
 }
 
 function plainSetCaret(pos: number) {
@@ -1016,6 +1032,40 @@ function handlePlainKeydownShared(event: KeyboardEvent): boolean {
   return false;
 }
 
+/**
+ * Markdown list / quote continuation on Enter (matches CodeMirror's behaviour):
+ * Enter at the end of a list/quote item starts the next item (ordered numbers
+ * increment); Enter on an empty item removes the marker and ends the list.
+ * Returns the new {value, caret} or null to let the textarea handle Enter.
+ */
+function computeSmartEnter(el: HTMLTextAreaElement): { value: string; caret: number } | null {
+  if (el.selectionStart !== el.selectionEnd) return null;
+  const v = el.value;
+  const caret = el.selectionStart ?? 0;
+  const lineStart = v.lastIndexOf('\n', caret - 1) + 1;
+  const nl = v.indexOf('\n', caret);
+  const lineEnd = nl < 0 ? v.length : nl;
+  const line = v.slice(lineStart, lineEnd);
+
+  const ul = line.match(/^(\s*)([-*+])\s+(\[[ xX]\]\s+)?(.*)$/);
+  const ol = line.match(/^(\s*)(\d+)([.)])\s+(.*)$/);
+  const bq = line.match(/^(\s*)(>)\s?(.*)$/);
+  let marker: string | null = null;
+  let content = '';
+  if (ul) { marker = `${ul[1]}${ul[2]} ${ul[3] ? '[ ] ' : ''}`; content = ul[4]; }
+  else if (ol) { marker = `${ol[1]}${Number(ol[2]) + 1}${ol[3]} `; content = ol[4]; }
+  else if (bq) { marker = `${bq[1]}> `; content = bq[3]; }
+  if (marker === null) return null;
+
+  // Empty item → remove the marker (end the list), leaving a blank line.
+  if (content.trim() === '') {
+    return { value: v.slice(0, lineStart) + v.slice(caret), caret: lineStart };
+  }
+  // Continue the list/quote with a fresh marker.
+  const insert = `\n${marker}`;
+  return { value: v.slice(0, caret) + insert + v.slice(caret), caret: caret + insert.length };
+}
+
 function handlePlainBlockKeydown(index: number, event: KeyboardEvent) {
   if (plainComposing) return;
   if (handleAutocompleteKeydown(event)) return;
@@ -1035,6 +1085,23 @@ function handlePlainBlockKeydown(index: number, event: KeyboardEvent) {
         e2.setSelectionRange(edit.selStart, edit.selEnd);
       }
     });
+    return;
+  }
+  if (event.key === 'Enter' && !event.shiftKey && !event.ctrlKey && !event.metaKey && !event.altKey) {
+    const el = event.target as HTMLTextAreaElement;
+    const smart = computeSmartEnter(el);
+    if (smart) {
+      event.preventDefault();
+      updatePlainBlock(index, smart.value, smart.caret);
+      nextTick(() => {
+        const e2 = plainBlockEditors.value[plainActiveBlock.value];
+        if (e2) {
+          e2.focus();
+          const p = Math.min(smart.caret, e2.value.length);
+          e2.setSelectionRange(p, p);
+        }
+      });
+    }
   }
 }
 
@@ -1827,7 +1894,7 @@ const cls = computed(() => ({
 <template>
   <div v-if="!usePlainWindowsEditor" :class="cls" ref="host"></div>
   <div v-else class="plain-host">
-    <div v-if="plainLiveEnabled" ref="plainLiveHost" :class="[cls, 'plain-block-editor']" :style="plainEditorStyle">
+    <div v-if="plainLiveEnabled" ref="plainLiveHost" :class="[cls, 'plain-block-editor', { 'plain-focus': props.focusMode }]" :style="plainEditorStyle">
       <div
         v-for="(block, index) in plainBlocks"
         :key="block.id"
@@ -2076,6 +2143,10 @@ const cls = computed(() => ({
   white-space: pre-wrap;
   overflow-wrap: break-word;
   overflow-x: hidden;
+}
+.plain-block-editor.plain-focus .plain-block:not(.plain-block--active) {
+  opacity: 0.35;
+  transition: opacity 0.25s ease;
 }
 .plain-block-editor {
   overflow: auto;

--- a/app/src/lib/cm-image-paste.ts
+++ b/app/src/lib/cm-image-paste.ts
@@ -177,6 +177,25 @@ async function saveAndInsert(
   ext: string,
   opts: ImagePasteOptions,
 ): Promise<void> {
+  const insertText = await saveImageBytes(bytes, ext, opts);
+  if (!insertText) return;
+  const pos = view.state.selection.main.head;
+  view.dispatch({
+    changes: { from: pos, insert: insertText },
+    selection: { anchor: pos + insertText.length },
+  });
+}
+
+/**
+ * Persist image bytes to the right location (front-matter imageRoot / assets dir
+ * / temp) and return the markdown link to insert, or null on failure. Shared by
+ * the CodeMirror editor and the Windows plain-textarea editor.
+ */
+export async function saveImageBytes(
+  bytes: Uint8Array,
+  ext: string,
+  opts: ImagePasteOptions,
+): Promise<string | null> {
   let sepCh: string;
   try {
     sepCh = sep();
@@ -229,14 +248,40 @@ async function saveAndInsert(
   } catch (err) {
     // Best-effort: log and abort this image.
     console.error('[cm-image-paste] failed to write image', err);
-    return;
+    return null;
   }
 
-  const pos = view.state.selection.main.head;
-  view.dispatch({
-    changes: { from: pos, insert: insertText },
-    selection: { anchor: pos + insertText.length },
-  });
+  return insertText;
+}
+
+/**
+ * Clipboard image paste for a plain `<textarea>` editor. Extracts image items,
+ * saves them, and calls `insert` with each markdown link. Returns true if it
+ * handled (and consumed) the paste.
+ */
+export async function handleTextareaImagePaste(
+  event: ClipboardEvent,
+  opts: ImagePasteOptions,
+  insert: (text: string) => void,
+): Promise<boolean> {
+  const cd = event.clipboardData;
+  if (!cd || !cd.items) return false;
+  const images: Array<{ blob: Blob; ext: string }> = [];
+  for (let i = 0; i < cd.items.length; i++) {
+    const item = cd.items[i];
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      const f = item.getAsFile();
+      if (f) images.push({ blob: f, ext: extFromName(f.name) || extFromMime(item.type) });
+    }
+  }
+  if (images.length === 0) return false;
+  event.preventDefault();
+  for (const img of images) {
+    const bytes = await readFileAsUint8(img.blob);
+    const text = await saveImageBytes(bytes, img.ext, opts);
+    if (text) insert(text);
+  }
+  return true;
 }
 
 async function handlePaste(

--- a/docs/webview2-ime-report/REPORT.md
+++ b/docs/webview2-ime-report/REPORT.md
@@ -1,0 +1,74 @@
+# WebView2 drops first CJK IME character and requires double-input for Chinese punctuation in `contentEditable`
+
+> Submit at: https://github.com/MicrosoftEdge/WebView2Feedback/issues
+> (Search existing issues for "IME" / "composition" / "contentEditable" first and add a 👍 / comment if a matching one exists.)
+
+## Summary
+
+In a WebView2-hosted page, typing Chinese with an IME into a `contentEditable`
+element exhibits two defects:
+
+1. **First character is dropped (“吃字”)** — the first character of a composition
+   after focusing the element is silently lost.
+2. **Chinese punctuation must be typed twice** — full-width punctuation
+   (`，` `。` `？` `！`) does not commit on the first keypress; it takes two.
+
+The **same input works correctly in a plain `<textarea>`** on the same page,
+same IME, same session. This points at WebView2's IME / TSF integration for
+`contentEditable`, not the IME itself.
+
+The problem is **most severe with Sogou Pinyin (搜狗拼音)**, which is the most
+widely used third-party IME in China. Microsoft Pinyin reproduces it more mildly.
+
+## Environment
+
+- WebView2 Runtime (Evergreen): **149.0.4022.69** (matches Edge Stable 149.0.4022.69; Chromium 149)
+- OS: Windows 11 (10.0.26200)
+- Host framework: Tauri 2 (also reproducible in a standalone WebView2 host and worth comparing against Edge)
+- IME: Sogou Pinyin (severe); Microsoft Pinyin (mild)
+
+## Minimal reproduction
+
+A self-contained `repro.html` is attached (also inline below). It places a
+`contentEditable` div and a `<textarea>` side by side and logs composition /
+`beforeinput` / `input` events for the `contentEditable`.
+
+Steps:
+1. Open `repro.html` in the WebView2 host (and in Edge for comparison).
+2. Switch to **Sogou Pinyin**.
+3. Click the **contentEditable** box, type `nihao，shijie。` (pinyin + space to
+   commit each word, then a Chinese comma and period).
+4. Repeat in the **textarea** box.
+
+## Expected
+
+Both inputs produce `你好，世界。`, with every character and punctuation mark
+committing on the first attempt.
+
+## Actual
+
+- **contentEditable:** the first character is missing, and the commas/periods
+  required a second keypress to appear. Result is corrupted / missing characters.
+- **textarea:** correct (`你好，世界。`).
+
+## Notes for triage
+
+- Reproduces on the latest Evergreen runtime (149), so it is not fixed by
+  updating the runtime.
+- JS-side mitigation attempts (suppressing DOM mutations on the composing node
+  during `compositionstart` → `compositionend`, i.e. not rebuilding the editable
+  subtree mid-composition) do **not** resolve it — the dropped first char and
+  doubled punctuation persist, which suggests the issue is below the DOM/JS layer
+  in WebView2's TSF text-input handling.
+- The `<textarea>` (native text input path) being unaffected is the key
+  contrast: the same keystrokes/IME succeed there.
+- Please confirm whether this also reproduces in Edge Stable with the same
+  Chromium base — if Edge is unaffected but WebView2 is, it is WebView2-specific;
+  if both are affected, it is a Chromium/Edge text-input regression.
+
+## Impact
+
+Any rich-text / code editor built on `contentEditable` (CodeMirror 6, ProseMirror,
+Slate, Monaco-in-contentEditable mode, etc.) is unusable for Chinese users in
+WebView2 — forcing apps to fall back to a plain `<textarea>` and lose
+syntax highlighting, WYSIWYG, and other editor features on Windows specifically.

--- a/docs/webview2-ime-report/repro.html
+++ b/docs/webview2-ime-report/repro.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>WebView2 CJK IME bug — contentEditable vs textarea</title>
+<style>
+  body { font: 14px/1.6 system-ui, "Segoe UI", sans-serif; margin: 24px; color: #1a1a1a; }
+  h1 { font-size: 18px; }
+  .row { display: flex; gap: 24px; flex-wrap: wrap; margin-top: 16px; }
+  .box { flex: 1 1 360px; }
+  .label { font-weight: 600; margin-bottom: 6px; }
+  .bug { color: #c0392b; }
+  .ok { color: #1e8449; }
+  [contenteditable], textarea {
+    width: 100%; min-height: 120px; box-sizing: border-box; padding: 10px;
+    border: 1px solid #bbb; border-radius: 6px; font: 16px/1.7 "Microsoft YaHei", sans-serif;
+    white-space: pre-wrap; outline: none;
+  }
+  [contenteditable]:focus, textarea:focus { border-color: #2980b9; }
+  pre { background: #f4f4f4; padding: 10px; border-radius: 6px; max-height: 220px; overflow: auto; font-size: 12px; }
+  .env { color: #555; font-size: 12px; margin-top: 8px; }
+  ol { padding-left: 20px; }
+</style>
+</head>
+<body>
+  <h1>WebView2 中文输入法 (CJK IME) bug — contentEditable vs &lt;textarea&gt;</h1>
+
+  <p><strong>How to reproduce:</strong></p>
+  <ol>
+    <li>Open this page in a WebView2 host (or in Microsoft Edge for comparison).</li>
+    <li>Switch to a Chinese IME — <strong>Sogou Pinyin (搜狗拼音) shows it most severely</strong>; Microsoft Pinyin may be milder.</li>
+    <li>Click the <span class="bug">contentEditable</span> box and type a sentence with punctuation, e.g. <code>nihao，shijie。</code> (pinyin + space to commit, then Chinese comma/period).</li>
+    <li>Do the same in the <span class="ok">textarea</span> box.</li>
+  </ol>
+
+  <p><strong>Observed in contentEditable (BUG):</strong> the <em>first</em> character after focusing is dropped (“吃字”), and Chinese punctuation must be typed twice before it commits. The same input in the plain <code>&lt;textarea&gt;</code> works correctly.</p>
+
+  <div class="row">
+    <div class="box">
+      <div class="label bug">contentEditable (BUG here)</div>
+      <div id="ce" contenteditable="true"></div>
+    </div>
+    <div class="box">
+      <div class="label ok">&lt;textarea&gt; (works correctly)</div>
+      <textarea id="ta"></textarea>
+    </div>
+  </div>
+
+  <div class="label" style="margin-top:18px;">contentEditable IME event log (composition / beforeinput / input)</div>
+  <pre id="log"></pre>
+
+  <div class="env" id="env"></div>
+
+  <script>
+    const ce = document.getElementById('ce');
+    const log = document.getElementById('log');
+    const lines = [];
+    function rec(type, ev) {
+      const data = ev && ('data' in ev) ? JSON.stringify(ev.data) : '';
+      const it = ev && ev.inputType ? ' inputType=' + ev.inputType : '';
+      const ic = ev && ('isComposing' in ev) ? ' isComposing=' + ev.isComposing : '';
+      lines.push(`${type}${it}${ic} data=${data} text=${JSON.stringify(ce.textContent)}`);
+      if (lines.length > 200) lines.shift();
+      log.textContent = lines.join('\n');
+      log.scrollTop = log.scrollHeight;
+    }
+    ['compositionstart','compositionupdate','compositionend','beforeinput','input','keydown']
+      .forEach(e => ce.addEventListener(e, ev => rec(e, ev), true));
+
+    // Environment info to paste into the bug report.
+    const env = [
+      'userAgent: ' + navigator.userAgent,
+      'platform: ' + navigator.platform,
+      'languages: ' + (navigator.languages || []).join(', '),
+    ].join('\n');
+    document.getElementById('env').textContent = env;
+  </script>
+</body>
+</html>

--- a/scripts/dev/editor-smoke.ps1
+++ b/scripts/dev/editor-smoke.ps1
@@ -134,6 +134,15 @@ return { pass: el.getAttribute('wrap')==='soft'&&cs.whiteSpace==='pre-wrap', det
   @{ n='spellcheck enabled'; seed='teh recieve'; body=@'
 const el=A(); return { pass: el.getAttribute('spellcheck')==='true', detail:{spellcheck:el.getAttribute('spellcheck')} };
 '@ }
+  @{ n='slash command: popup + filter + insert'; seed=$null; body=@'
+await waitEditor(); let el=A(); el.focus();
+setV(el,'/'); el.setSelectionRange(1,1); el.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertText',data:'/'})); await sleep(200);
+const opened=!!document.querySelector('.plain-ac'); const n1=document.querySelectorAll('.plain-ac__item').length;
+setV(el,'/todo'); el.setSelectionRange(5,5); el.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertText',data:'o'})); await sleep(200);
+const labels=[...document.querySelectorAll('.plain-ac__item .plain-ac__label')].map(x=>x.textContent);
+el=A(); key(el,'Enter'); await sleep(250); el=A();
+return { pass: opened && n1>0 && labels.length===1 && el.value==='- [ ] ' && !document.querySelector('.plain-ac'), detail:{opened,n1,labels,val:JSON.stringify(el.value)} };
+'@ }
 )
 
 # Force liveEdit once.

--- a/scripts/dev/editor-smoke.ps1
+++ b/scripts/dev/editor-smoke.ps1
@@ -1,0 +1,168 @@
+<#
+.SYNOPSIS
+  Editor regression smoke test for the Windows plain-textarea editor (SoloMD).
+
+.DESCRIPTION
+  Drives the running `tauri dev` SoloMD instance through the dev-bridge
+  (HTTP /eval) and exercises the editor end to end: new-doc focus, typing,
+  selection replace, Enter, Tab indent, undo/redo, task-checkbox toggle,
+  find/replace, word-wrap and spellcheck attributes. Each test reloads the app
+  for a clean document, seeds content, performs an action, and asserts the
+  result. Prints a pass/fail table.
+
+  Requires: a running `tauri dev` instance (dev-bridge writes its port/token to
+  %APPDATA%\app.solomd\dev-bridge.{port,token}). viewMode is forced to liveEdit.
+
+.EXAMPLE
+  pwsh -File scripts/dev/editor-smoke.ps1
+#>
+
+$ErrorActionPreference = 'Stop'
+$port  = (Get-Content "$env:APPDATA\app.solomd\dev-bridge.port").Trim()
+$token = (Get-Content "$env:APPDATA\app.solomd\dev-bridge.token").Trim()
+Write-Host "dev-bridge: 127.0.0.1:$port" -ForegroundColor Cyan
+
+function Invoke-Eval([string]$js, [int]$timeoutMs = 15000) {
+  $body = @{ script = $js; timeout_ms = $timeoutMs } | ConvertTo-Json -Depth 8
+  $r = Invoke-RestMethod -Uri "http://127.0.0.1:$port/eval" -Method Post `
+      -Headers @{ Authorization = "Bearer $token" } -ContentType 'application/json' `
+      -Body $body -NoProxy -TimeoutSec 30
+  if (-not $r.ok) { throw "eval error: $($r.error)" }
+  return $r.value
+}
+
+# Shared JS helpers injected before every test body.
+$prelude = @'
+const sleep=(ms)=>new Promise(r=>setTimeout(r,ms));
+const setV=(el,v)=>{const p=Object.getPrototypeOf(el);Object.getOwnPropertyDescriptor(p,'value').set.call(el,v);};
+const A=()=>document.querySelector('.plain-block--active textarea');
+const blocks=()=>[...document.querySelectorAll('.plain-block')];
+const activeIdx=()=>blocks().findIndex(b=>b.classList.contains('plain-block--active'));
+async function waitEditor(){ for(let i=0;i<30 && !document.querySelector('.plain-block textarea, .plain-editor');i++) await sleep(150); }
+async function seed(doc){ let ta=A()||document.querySelector('.plain-block textarea'); ta.focus(); setV(ta,doc); ta.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertText'})); await sleep(250); }
+async function imeCommit(el,s){ el.dispatchEvent(new CompositionEvent('compositionstart',{bubbles:true})); const a=el.selectionStart,b=el.selectionEnd; setV(el, el.value.slice(0,a)+s+el.value.slice(b)); el.setSelectionRange(a+s.length,a+s.length); el.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertCompositionText',data:s,isComposing:true})); el.dispatchEvent(new CompositionEvent('compositionend',{bubbles:true,data:s})); await sleep(140); }
+async function typeChar(ch){ let e=A(); const s=e.selectionStart; setV(e, e.value.slice(0,s)+ch+e.value.slice(s)); e.setSelectionRange(s+1,s+1); e.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertText',data:ch})); await sleep(650); }
+async function pressEnter(el){ const a=el.selectionStart; setV(el, el.value.slice(0,a)+'\n'+el.value.slice(a)); el.setSelectionRange(a+1,a+1); el.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertLineBreak'})); await sleep(200); }
+const key=(el,k,opt={})=>el.dispatchEvent(new KeyboardEvent('keydown',Object.assign({key:k,bubbles:true},opt)));
+'@
+
+# Each test: name, seed doc, and a JS body returning { pass: bool, detail: any }.
+$tests = @(
+  @{ n='new-doc auto-focus'; seed=$null; body=@'
+await waitEditor(); const ta=A();
+return { pass: !!ta && document.activeElement===ta, detail:{ active: document.activeElement?.tagName, hasTextarea:!!ta } };
+'@ }
+  @{ n='new-doc type'; seed=$null; body=@'
+await waitEditor(); let ta=A(); ta.focus(); setV(ta,'你好'); ta.setSelectionRange(2,2); ta.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertText',data:'好'})); await sleep(150);
+ta=A(); return { pass: ta && ta.value==='你好', detail:{ val: ta?.value } };
+'@ }
+  @{ n='paragraph: type at start'; seed='# H\n\n普通段落内容\n\n末段'; body=@'
+let i=blocks().findIndex(b=>b.querySelector('.plain-block__render')?.textContent.includes('普通段落')); blocks()[i].click(); await sleep(150);
+let el=A(); el.setSelectionRange(0,0); await imeCommit(el,'你好'); el=A();
+return { pass: el&&el.value==='你好普通段落内容'&&el.selectionStart===2&&activeIdx()===i, detail:{val:el?.value,caret:el?.selectionStart} };
+'@ }
+  @{ n='paragraph: type at end (no newline)'; seed='# H\n\n普通段落内容\n\n末段'; body=@'
+let i=blocks().findIndex(b=>b.querySelector('.plain-block__render')?.textContent.includes('普通段落')); blocks()[i].click(); await sleep(150);
+let el=A(); el.setSelectionRange(el.value.length,el.value.length); await imeCommit(el,'好'); el=A();
+return { pass: el&&el.value==='普通段落内容好'&&!el.value.includes('\n'), detail:{val:JSON.stringify(el?.value)} };
+'@ }
+  @{ n='paragraph: selection replace'; seed='# H\n\n普通段落内容\n\n末段'; body=@'
+let i=blocks().findIndex(b=>b.querySelector('.plain-block__render')?.textContent.includes('普通段落')); blocks()[i].click(); await sleep(150);
+let el=A(); el.setSelectionRange(0,2); await imeCommit(el,'测试'); el=A();
+return { pass: el&&el.value==='测试段落内容'&&activeIdx()===i, detail:{val:el?.value} };
+'@ }
+  @{ n='whole-line select replace (no preview flip)'; seed='# H\n\n整段文字\n\n末段'; body=@'
+let i=blocks().findIndex(b=>b.querySelector('.plain-block__render')?.textContent.includes('整段文字')); blocks()[i].click(); await sleep(150);
+let el=A(); el.setSelectionRange(0,el.value.length); await imeCommit(el,'你好'); el=A();
+return { pass: !!el&&el.value==='你好'&&activeIdx()===i, detail:{val:el?.value,stillEditing:!!el} };
+'@ }
+  @{ n='list: type before "-" marker'; seed='- 列表项一\n- 列表项二\n- 列表项三'; body=@'
+let el=A(); el.setSelectionRange(0,0); setV(el,'x'+el.value); el.setSelectionRange(1,1); el.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertText',data:'x'})); await sleep(150); el=A();
+return { pass: !!el&&el.selectionStart===1&&el.value==='x- 列表项一', detail:{caret:el?.selectionStart,val:el?.value} };
+'@ }
+  @{ n='multiline block: type at 2nd line start'; seed='第一行\n第二行\n第三行'; body=@'
+let el=A(); const p2=el.value.indexOf('\n')+1; el.setSelectionRange(p2,p2); await imeCommit(el,'你好'); el=A();
+return { pass: !!el&&el.value==='第一行\n你好第二行\n第三行'&&el.selectionStart===p2+2, detail:{val:JSON.stringify(el?.value)} };
+'@ }
+  @{ n='Enter at mid paragraph row-end'; seed='第一段\n\n第二段\n\n第三段'; body=@'
+blocks()[0].click(); await sleep(150); let el=A(); el.setSelectionRange(el.value.length,el.value.length); const i0=activeIdx();
+await pressEnter(el); const cur=A();
+return { pass: !!cur&&activeIdx()===i0+1&&cur.selectionStart===0&&document.activeElement===cur, detail:{idx:activeIdx(),caret:cur?.selectionStart,focused:document.activeElement===cur} };
+'@ }
+  @{ n='Enter at last block end (new line + focus)'; seed='第一段\n\n最后一段'; body=@'
+let i=blocks().length-1; blocks()[i].click(); await sleep(150); let el=A(); el.setSelectionRange(el.value.length,el.value.length); const b0=blocks().length;
+await pressEnter(el); const cur=A();
+return { pass: !!cur&&cur.value===''&&cur.selectionStart===0&&document.activeElement===cur&&blocks().length===b0+1, detail:{val:JSON.stringify(cur?.value),focused:document.activeElement===cur,blocks:blocks().length} };
+'@ }
+  @{ n='Tab indent (caret after indent)'; seed='测试段落'; body=@'
+let el=A(); el.focus(); el.setSelectionRange(0,0); key(el,'Tab'); await sleep(200); el=A();
+return { pass: el&&el.value==='  测试段落'&&el.selectionStart===2, detail:{val:JSON.stringify(el?.value),caret:el?.selectionStart} };
+'@ }
+  @{ n='undo / redo'; seed='测试'; body=@'
+let el=A(); el.setSelectionRange(el.value.length,el.value.length); await typeChar('甲'); await typeChar('乙');
+const typed=A().value; key(A(),'z',{ctrlKey:true}); await sleep(300); const u1=A()?.value; key(A(),'z',{ctrlKey:true,shiftKey:true}); await sleep(300); const r1=A()?.value;
+return { pass: typed==='测试甲乙'&&u1==='测试甲'&&r1==='测试甲乙', detail:{typed,u1,r1} };
+'@ }
+  @{ n='task checkbox toggle'; seed='# T\n\n- [ ] 任务一\n- [x] 任务二\n\n末尾段落'; body=@'
+const ti=blocks().findIndex(b=>b.querySelector('.plain-block__render')?.textContent.includes('任务一'));
+const box=blocks()[ti].querySelector('input.task-list-item-checkbox'); const disabled=box.disabled;
+box.dispatchEvent(new MouseEvent('click',{bubbles:true})); await sleep(250);
+const t2=blocks().findIndex(b=>b.querySelector('.plain-block__render')?.textContent.includes('任务一')); blocks()[t2].click(); await sleep(150);
+const src=A()?.value;
+return { pass: !disabled && /- \[x\] 任务一/.test(src||''), detail:{disabled, src:JSON.stringify(src)} };
+'@ }
+  @{ n='find: count + next selects'; seed='苹果 香蕉 苹果\n\n橙子 苹果'; body=@'
+key(A(),'f',{ctrlKey:true}); await sleep(250); const open=!!document.querySelector('.plain-find');
+const fi=document.querySelector('.plain-find__input'); setV(fi,'苹果'); fi.dispatchEvent(new Event('input',{bubbles:true})); await sleep(200);
+const count=document.querySelector('.plain-find__count')?.textContent;
+[...document.querySelectorAll('.plain-find__btn')][1].dispatchEvent(new MouseEvent('click',{bubbles:true})); await sleep(200);
+const e=A(); const sel=e?e.value.slice(e.selectionStart,e.selectionEnd):'';
+return { pass: open&&count==='1/3'&&sel==='苹果', detail:{open,count,sel} };
+'@ }
+  @{ n='replace all'; seed='苹果 香蕉 苹果\n\n橙子 苹果'; body=@'
+key(A(),'f',{ctrlKey:true}); await sleep(200);
+const fi=document.querySelector('.plain-find__input'); setV(fi,'苹果'); fi.dispatchEvent(new Event('input',{bubbles:true})); await sleep(150);
+const ri=document.querySelectorAll('.plain-find__input')[1]; setV(ri,'梨'); ri.dispatchEvent(new Event('input',{bubbles:true})); await sleep(100);
+[...document.querySelectorAll('.plain-find__btn')].find(b=>b.textContent.trim()==='All').dispatchEvent(new MouseEvent('click',{bubbles:true})); await sleep(300);
+const t=[]; const bs=blocks(); for(let i=0;i<bs.length;i++){ bs[i].click(); await sleep(120); t.push(A()?.value||''); }
+const doc=t.join('\n\n'); return { pass: !doc.includes('苹果')&&(doc.match(/梨/g)||[]).length===3, detail:{doc:JSON.stringify(doc)} };
+'@ }
+  @{ n='word-wrap follows setting'; seed='这是一段很长很长的文字用来测试自动换行是否生效'; body=@'
+const el=A(); const cs=getComputedStyle(el);
+return { pass: el.getAttribute('wrap')==='soft'&&cs.whiteSpace==='pre-wrap', detail:{wrap:el.getAttribute('wrap'),ws:cs.whiteSpace} };
+'@ }
+  @{ n='spellcheck enabled'; seed='teh recieve'; body=@'
+const el=A(); return { pass: el.getAttribute('spellcheck')==='true', detail:{spellcheck:el.getAttribute('spellcheck')} };
+'@ }
+)
+
+# Force liveEdit once.
+try { Invoke-Eval "const s=JSON.parse(localStorage.getItem('solomd.settings.v1')||'{}'); s.viewMode='liveEdit'; s.wordWrap=true; s.spellCheck=true; localStorage.setItem('solomd.settings.v1',JSON.stringify(s)); return 1;" 5000 | Out-Null } catch {}
+
+$results = @()
+foreach ($t in $tests) {
+  # Reload to a clean Untitled doc for isolation.
+  try { Invoke-Eval "for(const k of Object.keys(localStorage)){if(k.startsWith('solomd.tabs'))localStorage.removeItem(k);} location.reload(); return 1;" 2000 | Out-Null } catch {}
+  Start-Sleep -Seconds 3
+  $seedJs = if ($null -ne $t.seed) { "await waitEditor(); await seed('" + $t.seed + "');" } else { "" }
+  $full = $prelude + "`ntry{ $seedJs`n" + $t.body + "`n}catch(e){ return { pass:false, detail:{error:String(e)} }; }"
+  try {
+    $v = Invoke-Eval $full 18000
+    $results += [pscustomobject]@{ Test=$t.n; Pass=[bool]$v.pass; Detail=($v.detail | ConvertTo-Json -Compress -Depth 6) }
+  } catch {
+    $results += [pscustomobject]@{ Test=$t.n; Pass=$false; Detail="HARNESS ERROR: $($_.Exception.Message)" }
+  }
+}
+
+Write-Host ""
+$results | ForEach-Object {
+  $mark = if ($_.Pass) { '[PASS]' } else { '[FAIL]' }
+  $color = if ($_.Pass) { 'Green' } else { 'Red' }
+  Write-Host ("{0} {1}" -f $mark, $_.Test) -ForegroundColor $color
+  if (-not $_.Pass) { Write-Host ("        -> {0}" -f $_.Detail) -ForegroundColor DarkGray }
+}
+$passed = ($results | Where-Object Pass).Count
+$summaryColor = if ($passed -eq $results.Count) { 'Green' } else { 'Yellow' }
+Write-Host ""
+Write-Host ("PASSED {0}/{1}" -f $passed, $results.Count) -ForegroundColor $summaryColor
+if ($passed -ne $results.Count) { exit 1 }

--- a/scripts/dev/editor-smoke.ps1
+++ b/scripts/dev/editor-smoke.ps1
@@ -134,6 +134,21 @@ return { pass: el.getAttribute('wrap')==='soft'&&cs.whiteSpace==='pre-wrap', det
   @{ n='spellcheck enabled'; seed='teh recieve'; body=@'
 const el=A(); return { pass: el.getAttribute('spellcheck')==='true', detail:{spellcheck:el.getAttribute('spellcheck')} };
 '@ }
+  @{ n='smart Enter: continue bullet list'; seed='- 项一'; body=@'
+let el=A(); el.setSelectionRange(el.value.length,el.value.length); key(el,'Enter'); await sleep(200); el=A();
+return { pass: el.value==='- 项一\n- '&&el.selectionStart===el.value.length, detail:{val:JSON.stringify(el.value),caret:el.selectionStart} };
+'@ }
+  @{ n='smart Enter: end list on empty item'; seed='- 项一'; body=@'
+let el=A(); el.setSelectionRange(el.value.length,el.value.length); key(el,'Enter'); await sleep(200); el=A();
+key(el,'Enter'); await sleep(250);
+const cur=A(); const endedEmpty = !!cur && cur.value==='';
+const txt=blocks().map(b=>(b.querySelector('.plain-block__render')?.textContent||b.querySelector('textarea')?.value||''));
+return { pass: endedEmpty && txt.some(t=>t.includes('项一')) && !txt.some(t=>/项一[\s\S]*-\s*$/.test(t)), detail:{endedEmpty,txt} };
+'@ }
+  @{ n='smart Enter: ordered list increments'; seed='1. 甲'; body=@'
+let el=A(); el.setSelectionRange(el.value.length,el.value.length); key(el,'Enter'); await sleep(200); el=A();
+return { pass: el.value==='1. 甲\n2. ', detail:{val:JSON.stringify(el.value)} };
+'@ }
   @{ n='slash command: popup + filter + insert'; seed=$null; body=@'
 await waitEditor(); let el=A(); el.focus();
 setV(el,'/'); el.setSelectionRange(1,1); el.dispatchEvent(new InputEvent('input',{bubbles:true,inputType:'insertText',data:'/'})); await sleep(200);


### PR DESCRIPTION
> 续 #122(已合并 v4.6.5)。WebView2 的 contentEditable 中文输入法 bug 无法根治(运行时已最新 149;CodeMirror 合成冻结实测仍首字被吃 + 标点双输入;已提报 MicrosoftEdge/WebView2Feedback#5625),故 Windows 保留 textarea 块编辑器,本 PR 把它补强到与旧 CodeMirror 编辑器**几乎完全一致**。

## 输入法 / 光标修复
每输入一个换行、选中一行进预览、列表标记前光标跳尾、行末回车光标不动、点击预览定位、新建/切换文档无法输入(自动聚焦)、自动换行跟随设置。

## 找回的编辑器能力(对照旧 CodeMirror)
| 能力 | 状态 |
|---|---|
| 撤销/重做、Tab 缩进、拼写检查 | ✅ |
| 剪贴板贴图、任务清单勾选 | ✅ |
| 查找/替换(Ctrl+F) | ✅ |
| 编辑时 Markdown 语法高亮 | ✅ |
| 自动补全 `/` `[[` `#` `@` | ✅ |
| 专注模式、打字机模式 | ✅ |
| 智能列表/引用续行(回车) | ✅ |
| AI 改写(Ctrl/Cmd+J) | ✅ |
| 跳转行、会话恢复、光标/字数上报、工具栏格式 | ✅ |

## 受架构限制无法等价(textarea 块编辑器 vs CodeMirror)
行号槽(块/预览混排无法对齐)、Vim 模式、列/矩形选择、括号配对高亮。这些是"几乎"二字的来源。

## 测试
`scripts/dev/editor-smoke.ps1` 回归工具 **21/21 通过**(真实 WebView2 dev-bridge 驱动);vue-tsc + 生产构建通过。微软复现材料见 `docs/webview2-ime-report/`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)