### PR TITLE
Keep local SVG previews visible across WebViews

### DIFF
--- a/app/src/components/Editor.vue
+++ b/app/src/components/Editor.vue
@@ -54,7 +54,7 @@ import {
   clearSession,
 } from '../lib/cm-session-restore';
 import { renderMarkdown, extractImageRoot as extractMarkdownImageRoot } from '../lib/markdown';
-import { rewriteImageUrls } from '../lib/image-resolve';
+import { installSvgImageFallbacks, rewriteImageUrls } from '../lib/image-resolve';
 import { SLASH_BLOCKS, filterBlocks, expandSnippet } from '../lib/slash-blocks';
 import { useWorkspaceIndexStore } from '../stores/workspaceIndex';
 
@@ -241,6 +241,7 @@ async function processPlainLiveRenderedBlocks() {
   if (!plainLiveEnabled.value || !plainLiveHost.value) return;
   await nextTick();
   const hostEl = plainLiveHost.value;
+  installSvgImageFallbacks(hostEl);
 
   const mermaidBlocks = hostEl.querySelectorAll('.plain-block__render pre > code.language-mermaid');
   for (const block of Array.from(mermaidBlocks)) {

--- a/app/src/components/Preview.vue
+++ b/app/src/components/Preview.vue
@@ -3,7 +3,7 @@ import { computed, ref, watch, onMounted, onBeforeUnmount, nextTick } from 'vue'
 import mermaid from 'mermaid';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { renderMarkdown, extractImageRoot } from '../lib/markdown';
-import { rewriteImageUrls } from '../lib/image-resolve';
+import { installSvgImageFallbacks, rewriteImageUrls } from '../lib/image-resolve';
 import { openImageOverlay, type OverlayStrings } from '../lib/image-overlay';
 import { useI18n } from '../i18n';
 import { useSettingsStore } from '../stores/settings';
@@ -250,6 +250,8 @@ function overlayStrings(): OverlayStrings {
 
 function attachImageOverlayHandlers() {
   if (!host.value) return;
+
+  installSvgImageFallbacks(host.value);
 
   const images = host.value.querySelectorAll('img');
   for (const img of Array.from(images)) {

--- a/app/src/lib/cm-live-blocks.ts
+++ b/app/src/lib/cm-live-blocks.ts
@@ -36,7 +36,12 @@ import {
 // view plugin. `relayoutEffect` lets the async Mermaid render (and any other
 // out-of-band trigger) ask the field to recompute.
 const relayoutEffect = StateEffect.define<null>();
-import { resolveImageSrc } from './image-resolve';
+import {
+  installSvgImageFallbacks,
+  isLocalSvgPath,
+  resolveImagePath,
+  resolveImageSrc,
+} from './image-resolve';
 import { renderMarkdown, extractImageRoot } from './markdown';
 import mermaid from 'mermaid';
 import 'katex/contrib/mhchem';
@@ -99,12 +104,13 @@ class ImageWidget extends WidgetType {
   constructor(
     private readonly src: string,
     private readonly alt: string,
+    private readonly localPath: string | null = null,
   ) {
     super();
   }
 
   eq(other: ImageWidget): boolean {
-    return other.src === this.src && other.alt === this.alt;
+    return other.src === this.src && other.alt === this.alt && other.localPath === this.localPath;
   }
 
   toDOM(): HTMLElement {
@@ -115,14 +121,17 @@ class ImageWidget extends WidgetType {
     img.alt = this.alt;
     img.loading = 'lazy';
     img.draggable = false;
+    if (this.localPath) img.dataset.solomdLocalSrc = this.localPath;
     img.onerror = () => {
       // Image failed to load — fall back to a small "broken image" caption
       // rather than a giant empty box. The source text is one cursor-move
       // away regardless.
+      if (this.localPath) return;
       wrap.classList.add('cm-live-block--broken');
       wrap.textContent = `🖼 ${this.alt || this.src}`;
     };
     wrap.appendChild(img);
+    installSvgImageFallbacks(wrap);
     return wrap;
   }
 
@@ -531,11 +540,12 @@ function buildBlockDecorations(state: EditorState, opts: BlockOptions): Decorati
               const root = opts.getImageRoot?.() ?? null;
               const filePath = opts.getFilePath?.();
               const src = resolveImageSrc(rawSrc, root, filePath);
+              const localPath = resolveImagePath(rawSrc, root, filePath);
               builder.add(
                 line.from,
                 line.to,
                 Decoration.replace({
-                  widget: new ImageWidget(src, alt),
+                  widget: new ImageWidget(src, alt, isLocalSvgPath(localPath) ? localPath : null),
                   block: true,
                 }),
               );

--- a/app/src/lib/image-resolve.ts
+++ b/app/src/lib/image-resolve.ts
@@ -4,7 +4,7 @@
  * to convert local image paths into URLs the webview can load or bytes for embedding.
  */
 
-import { convertFileSrc } from '@tauri-apps/api/core';
+import { convertFileSrc, invoke } from '@tauri-apps/api/core';
 
 /**
  * Normalize a filesystem path so `convertFileSrc` produces a URL the
@@ -53,6 +53,15 @@ function decodeHtmlAttr(value: string): string {
     .replace(/&gt;/g, '>');
 }
 
+function encodeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 function decodeUriOnce(value: string): string {
   try {
     return decodeURIComponent(value);
@@ -84,6 +93,14 @@ function cleanLocalImageSrc(src: string): string {
   const attr = decodeHtmlAttr(src.trim());
   const withoutUrlSuffix = stripLocalImageUrlSuffix(attr);
   return fileUrlToPath(decodeUriOnce(withoutUrlSuffix));
+}
+
+export function isLocalSvgPath(value: string): boolean {
+  return /\.svg$/i.test(stripLocalImageUrlSuffix(value));
+}
+
+export function svgTextToDataUrl(svg: string): string {
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
 }
 
 /**
@@ -142,6 +159,25 @@ export function resolveImageSrc(
   }
 }
 
+export function resolveImageSrcWithMeta(
+  src: string,
+  imageRoot: string | null,
+  filePath?: string,
+): { src: string; localPath: string | null } {
+  if (!src || /^(https?|data|blob|asset|tauri):/i.test(src)) {
+    return { src, localPath: null };
+  }
+  const localPath = resolveImagePath(src, imageRoot, filePath);
+  if (/^(https?|data|blob|asset|tauri):/i.test(localPath)) {
+    return { src: localPath, localPath: null };
+  }
+  try {
+    return { src: convertFileSrc(localPath), localPath };
+  } catch {
+    return { src, localPath };
+  }
+}
+
 /** Rewrite all `<img src=…>` URLs in the rendered markdown HTML. */
 export function rewriteImageUrls(
   rawHtml: string,
@@ -160,9 +196,43 @@ export function rewriteImageUrls(
       if (!src || /^(https?|data|blob|asset|tauri):/i.test(src)) {
         return `${prefix}${q}${src}${q}`;
       }
-      return `${prefix}${q}${resolveImageSrc(src, imageRoot, filePath)}${q}`;
+      const resolved = resolveImageSrcWithMeta(src, imageRoot, filePath);
+      const nextPrefix = resolved.localPath && isLocalSvgPath(resolved.localPath)
+        ? prefix.replace(/^<img\b/i, `<img data-solomd-local-src="${encodeHtmlAttr(resolved.localPath)}"`)
+        : prefix;
+      return `${nextPrefix}${q}${resolved.src}${q}`;
     },
   );
+}
+
+async function loadLocalSvgDataUrl(path: string): Promise<string | null> {
+  try {
+    const result = await invoke<{ content: string }>('read_file', { path });
+    const svg = result.content.trimStart();
+    if (!svg.startsWith('<svg') && !svg.startsWith('<?xml')) return null;
+    return svgTextToDataUrl(result.content);
+  } catch {
+    return null;
+  }
+}
+
+export function installSvgImageFallbacks(root: ParentNode): void {
+  const images = root.querySelectorAll<HTMLImageElement>('img[data-solomd-local-src]');
+  for (const img of Array.from(images)) {
+    if (img.dataset.solomdSvgFallbackBound === '1') continue;
+    const path = img.dataset.solomdLocalSrc || '';
+    if (!isLocalSvgPath(path)) continue;
+    img.dataset.solomdSvgFallbackBound = '1';
+    const fallback = async () => {
+      if (img.src.startsWith('data:image/svg+xml')) return;
+      const dataUrl = await loadLocalSvgDataUrl(path);
+      if (dataUrl) img.src = dataUrl;
+    };
+    img.addEventListener('error', fallback, { once: true });
+    if (img.complete && img.naturalWidth === 0) {
+      void fallback();
+    }
+  }
 }
 
 /**

--- a/app/test-self.mjs
+++ b/app/test-self.mjs
@@ -1,6 +1,7 @@
 // Self-test for SoloMD pure libs (run with: npx tsx test-self.mjs)
 import { simplifiedToTraditional, traditionalToSimplified, pinyin, cjkWordCount } from './src/lib/chinese.ts';
 import { extractOutline, renderMarkdown } from './src/lib/markdown.ts';
+import { rewriteImageUrls, svgTextToDataUrl } from './src/lib/image-resolve.ts';
 import { cleanAIArtifacts, stripMarkdownToPlain } from './src/lib/clean-ai.ts';
 
 let pass = 0, fail = 0;
@@ -28,6 +29,26 @@ ok('renders mark highlight', html.includes('<mark>'));
 ok('renders footnote', html.includes('footnote'));
 ok('task-list-item class', html.includes('task-list-item'));
 ok('contains-task-list class', html.includes('contains-task-list'));
+
+globalThis.window = {
+  __TAURI_INTERNALS__: {
+    convertFileSrc: (filePath, protocol = 'asset') => `${protocol}://localhost/${encodeURIComponent(filePath)}`,
+  },
+};
+const svgHtml = rewriteImageUrls(
+  '<p><img src="../../assets/l2-s7-modules.svg" alt="S7"></p>',
+  null,
+  '/vault/specs/l2/section.md',
+);
+ok('local svg gets asset URL', svgHtml.includes('src="asset://localhost/'));
+ok('local svg keeps resolved path for fallback', svgHtml.includes('data-solomd-local-src="/vault/assets/l2-s7-modules.svg"'));
+const pngHtml = rewriteImageUrls(
+  '<p><img src="./pic.png" alt="pic"></p>',
+  null,
+  '/vault/specs/l2/section.md',
+);
+ok('non-svg image does not get svg fallback metadata', !pngHtml.includes('data-solomd-local-src'));
+ok('svg data URL encodes XML', svgTextToDataUrl('<svg><text>中 & A</text></svg>').startsWith('data:image/svg+xml;charset=utf-8,%3Csvg%3E'));
 
 const fmHtml = renderMarkdown('---\ntitle: Test\nauthor: Alex\n---\n\n# body');
 ok('frontmatter parsed', fmHtml.includes('md-frontmatter'));


### PR DESCRIPTION
## Summary
- Preserve resolved local SVG paths while keeping the normal Tauri `asset://` image path first.
- Add a lazy fallback that converts local SVGs to `data:image/svg+xml` only after the image fails to load.
- Apply the fallback to preview, live-edit image widgets, and Windows plain live blocks.

## Verification
- User verified SVG preview in the running SoloMD dev app.
- `test-self.mjs` bundled via esbuild: 55/55 passed.
- `./node_modules/.bin/vue-tsc --noEmit`
- `./node_modules/.bin/vite build`

## Notes
- `pnpm build` via the wrapper attempted a non-TTY dependency purge, so verification used the equivalent local binaries directly.
