### PR TITLE
Add MCP Toplist rank badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SoloMD
 
+[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fzhitongblog%2Fsolomd.svg)](https://mcptoplist.com/server/glama%2Fzhitongblog%2Fsolomd)
+
 > The editor where agents live.
 
 [![Latest release](https://img.shields.io/github/v/release/zhitongblog/solomd)](https://github.com/zhitongblog/solomd/releases/latest)


### PR DESCRIPTION
Hi! [MCP Toplist](https://mcptoplist.com) tracks 81,852 MCP servers across the major
registries, and **SoloMD** is currently ranked **#323**.

This PR adds a small live badge to your README showing that rank — it updates
automatically as the leaderboard changes:

[![MCP Toplist](https://mcptoplist.com/badge/glama%2Fzhitongblog%2Fsolomd.svg)](https://mcptoplist.com/server/glama%2Fzhitongblog%2Fsolomd)

Totally fine to close if you'd rather not — and if you'd like your server's
data corrected or removed from the leaderboard, just say so here or open an
issue at the site. Thanks for building SoloMD!
