### PR TITLE
feat(ai): add MiniMax BYOK provider

### DIFF
--- a/app/src/lib/ai-providers.ts
+++ b/app/src/lib/ai-providers.ts
@@ -32,6 +32,7 @@ export type ProviderId =
   | 'kimi'
   | 'volcengine'
   | 'siliconflow'
+  | 'minimax'
   // Aggregator
   | 'openrouter'
   // Local
@@ -194,6 +195,18 @@ export const PROVIDERS: ProviderConfig[] = [
     modelHint:
       'deepseek-ai/DeepSeek-V3 · Qwen/Qwen2.5-Coder-32B-Instruct · moonshotai/Kimi-K2-Instruct · meta-llama/Meta-Llama-3.1-70B-Instruct',
     signupUrl: 'https://cloud.siliconflow.cn/account/ak',
+  },
+  {
+    id: 'minimax',
+    label: 'MiniMax',
+    apiFormat: 'openai',
+    defaultModel: 'MiniMax-M3',
+    // Global OpenAI-compatible endpoint. The CN region
+    // (https://api.minimaxi.com/v1) is reachable by overriding the base URL
+    // in AI Settings — the proxy honors the per-provider base_url override.
+    defaultBaseUrl: 'https://api.minimax.io/v1',
+    modelHint: 'MiniMax-M3 · MiniMax-M2.7',
+    signupUrl: 'https://platform.minimax.io/',
   },
   // ---- Aggregator (one key, hundreds of models) ---------------------
   {


### PR DESCRIPTION
Reason: Add the MiniMax provider to the executable BYOK LLM catalog (provider-add).

## Changes
- Add `minimax` to the `ProviderId` union and the `PROVIDERS` array in `app/src/lib/ai-providers.ts`.
- Use the OpenAI Chat Completions wire format (`apiFormat: 'openai'`) with the global OpenAI-compatible endpoint (`https://api.minimax.io/v1`) as the default base URL.
- Set `MiniMax-M3` as the default model and surface `MiniMax-M3` and `MiniMax-M2.7` as the model hint quick-pick list.
- The CN region endpoint (`https://api.minimaxi.com/v1`) is reachable via the existing per-provider base URL override in AI Settings, which the Rust AI proxy honors.

## Verification
- Ran `npx vue-tsc --noEmit` (typecheck) in `app/` — passed with no errors.
