### PR TITLE
chore(aur): bump solomd-bin to 4.11.13 and sync with AUR

### DIFF
--- a/aur-solomd-bin/.SRCINFO
+++ b/aur-solomd-bin/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = solomd-bin
 	pkgdesc = A lightweight Markdown and plain text editor built with Tauri 2
-	pkgver = 4.1.0
+	pkgver = 4.11.13
 	pkgrel = 1
 	url = https://solomd.app
 	arch = x86_64
@@ -16,9 +16,9 @@ pkgbase = solomd-bin
 	conflicts = solomd
 	options = !strip
 	options = !debug
-	source = solomd-bin-4.1.0.AppImage::https://github.com/zhitongblog/solomd/releases/download/v4.1.0/SoloMD_4.1.0_amd64.AppImage
+	source = solomd-bin-4.11.13.AppImage::https://github.com/zhitongblog/solomd/releases/download/v4.11.13/SoloMD_4.11.13_amd64.AppImage
 	source = solomd.desktop
-	sha256sums = 1cf92f74be3d05ca3f7d418d71dc76095684a161939f144c7c304191e7af7d0f
+	sha256sums = b2fba77c80b60a0261c0208636b5dc4a568729210b3be38fc7fba7f687413e93
 	sha256sums = SKIP
 
 pkgname = solomd-bin

--- a/aur-solomd-bin/PKGBUILD
+++ b/aur-solomd-bin/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: zhitong <dev@solomd.local>
 pkgname=solomd-bin
-pkgver=4.1.0
+pkgver=4.11.13
 pkgrel=1
 pkgdesc='A lightweight Markdown and plain text editor built with Tauri 2'
 arch=('x86_64')
@@ -16,7 +16,7 @@ conflicts=('solomd')
 options=('!strip' '!debug')
 source=("${pkgname}-${pkgver}.AppImage::https://github.com/zhitongblog/solomd/releases/download/v${pkgver}/SoloMD_${pkgver}_amd64.AppImage"
         "solomd.desktop")
-sha256sums=('1cf92f74be3d05ca3f7d418d71dc76095684a161939f144c7c304191e7af7d0f'
+sha256sums=('b2fba77c80b60a0261c0208636b5dc4a568729210b3be38fc7fba7f687413e93'
             'SKIP')
 
 prepare() {

--- a/aur-solomd-bin/README.md
+++ b/aur-solomd-bin/README.md
@@ -1,0 +1,28 @@
+# SoloMD AUR Package
+
+This directory contains the source for the **`solomd-bin`** package on the
+[Arch User Repository (AUR)](https://aur.archlinux.org/packages/solomd-bin).
+
+## Published package
+
+[![AUR](https://img.shields.io/aur/version/solomd-bin)](https://aur.archlinux.org/packages/solomd-bin)
+
+The package is published on AUR and kept in sync with the latest SoloMD release
+via a daily auto-update job that checks GitHub releases.
+
+## Install
+
+```sh
+# With an AUR helper (yay / paru)
+yay -S solomd-bin
+
+# Or manually
+git clone https://aur.archlinux.org/solomd-bin.git
+cd solomd-bin
+makepkg -si
+```
+
+## Maintainership
+
+Maintained by [@gonwe](https://github.com/gonwe). Contributions welcome — open
+an issue on the AUR package page or submit a PR here to update this directory.


### PR DESCRIPTION
## Summary

Sync the in-repo `aur-solomd-bin/` with the published AUR package and bump it to the latest release.

The AUR package `solomd-bin` is now live at https://aur.archlinux.org/packages/solomd-bin, and this PR brings the in-repo copy up to date (it was stuck at v4.1.0 while the latest release is v4.11.13).

## Changes

- **Bump `pkgver`** `4.1.0` → `4.11.13`
- **Update `sha256sums`** with the hash of the v4.11.13 AppImage
- **Add `.SRCINFO`** (required by AUR tooling; generated via `makepkg --printsrcinfo`)
- **Add `README.md`** documenting the published package and install instructions

## Notes

- The AUR package is maintained by [@gonwe](https://github.com/gonwe) with a daily auto-update job that tracks GitHub releases.
- Happy to co-maintain, or to transfer AUR ownership to you if you'd prefer to maintain it yourself.
